### PR TITLE
Remove `export default` by default. Add `templateExportDefault` option to add it back.

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,10 @@ With that said, I did have to make some decisions about when and where to includ
 
 These configuration options are available in addition to [Prettier's standard config for JavaScript and Handlebars files](https://prettier.io/docs/en/options.html).
 
-| Name                  | Default | Description                                                                                             |
-| --------------------- | ------- | ------------------------------------------------------------------------------------------------------- |
-| `templateSingleQuote` | `false` | [Same as in Prettier](https://prettier.io/docs/en/options.html#quotes) but affecting only template tags |
+| Name                    | Default   | Description                                                                                                                                                                                     |
+| ----------------------- | --------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `templateExportDefault` | `false`   | If `true`, default export template tags will be prepended with `export default`.                                                                                                                |
+| `templateSingleQuote`   | undefined | [Same as in Prettier](https://prettier.io/docs/en/options.html#quotes) but affecting only template tags. If `undefined`, will fall back to whatever is set for the global `singleQuote` config. |
 
 <!-- TODO: | `templatePrintWidth`  | `80`    | [Same as in Prettier](https://prettier.io/docs/en/options.html#print-width) but affecting only template tags | -->
 

--- a/src/options.ts
+++ b/src/options.ts
@@ -7,8 +7,17 @@ import type {
 import type { BaseNode } from './types/ast';
 
 export interface Options extends ParserOptions<BaseNode> {
+  templateExportDefault?: boolean;
   templateSingleQuote?: boolean;
 }
+
+const templateExportDefault: BooleanSupportOption = {
+  since: '0.1.0',
+  category: 'Format',
+  type: 'boolean',
+  default: false,
+  description: 'Prepend default export template tags with "export default".',
+};
 
 /**
  * Extracts a valid `templateSingleQuote` option out of the provided options. If
@@ -31,5 +40,6 @@ const templateSingleQuote: BooleanSupportOption = {
 };
 
 export const options: SupportOptions = {
+  templateExportDefault,
   templateSingleQuote,
 };

--- a/src/types/raw.ts
+++ b/src/types/raw.ts
@@ -3,6 +3,7 @@ import type {
   CallExpression,
   ClassProperty,
   Identifier,
+  Node,
   TemplateLiteral,
 } from '@babel/types';
 import {
@@ -10,6 +11,7 @@ import {
   isCallExpression,
   isClassProperty,
   isIdentifier,
+  isNode,
   isTemplateLiteral,
 } from '@babel/types';
 import type { AstPath } from 'prettier';
@@ -39,7 +41,7 @@ export function isRawGlimmerArrayExpressionPath(
 
 /** Type predicate */
 export function isRawGlimmerArrayExpression(
-  value: BaseNode | null | undefined
+  value: Node | BaseNode | null | undefined
 ): value is RawGlimmerArrayExpression {
   return (
     isArrayExpression(value) && isRawGlimmerCallExpression(value.elements[0])
@@ -138,4 +140,14 @@ export function isRawGlimmerCallExpression(
  */
 export interface RawGlimmerIdentifier extends Identifier {
   name: typeof TEMPLATE_TAG_PLACEHOLDER; // This is just `string` so not SUPER useful, just documentation
+}
+
+/** Recursively checks if the node has a Glimmer Array Expression. */
+export function hasGlimmerArrayExpression(node: Node): boolean {
+  return (
+    isRawGlimmerArrayExpression(node) ||
+    ('expression' in node &&
+      isNode(node.expression) &&
+      hasGlimmerArrayExpression(node.expression))
+  );
 }

--- a/tests/unit-tests/__snapshots__/format.test.ts.snap
+++ b/tests/unit-tests/__snapshots__/format.test.ts.snap
@@ -33,7 +33,7 @@ class MyComponent extends Component {
 `;
 
 exports[`format > config > default > it formats ../cases/gjs/default-export.gjs 1`] = `
-"export default <template>
+"<template>
   Explicit default export module top level component. Explicit default export
   module top level component. Explicit default export module top level
   component. Explicit default export module top level component. Explicit
@@ -242,7 +242,7 @@ export interface Signature {
   Yields: [];
 }
 
-export default <template>
+<template>
   Explicit default export module top level component. Explicit default export
   module top level component. Explicit default export module top level
   component. Explicit default export module top level component. Explicit

--- a/tests/unit-tests/ambiguous/__snapshots__/arrow-parens-avoid.test.ts.snap
+++ b/tests/unit-tests/ambiguous/__snapshots__/arrow-parens-avoid.test.ts.snap
@@ -1,12 +1,12 @@
 // Vitest Snapshot v1
 
 exports[`ambiguous > config > arrowParens: "avoid" > (oh, no) => {} > with semi > it formats ../cases/gjs/default-export.gjs 1`] = `
-"export default <template>
+"<template>
   Explicit default export module top level component. Explicit default export
   module top level component. Explicit default export module top level
   component. Explicit default export module top level component. Explicit
   default export module top level component.
-</template>
+</template>;
 (oh, no) => {};
 "
 `;
@@ -63,7 +63,7 @@ const bool = false,
 `;
 
 exports[`ambiguous > config > arrowParens: "avoid" > (oh, no) => {} > with semi > it formats ../cases/gjs/simple.gjs 1`] = `
-"<template>what</template>
+"<template>what</template>;
 (oh, no) => {};
 "
 `;
@@ -77,7 +77,7 @@ export interface Signature {
   Yields: [];
 }
 
-export default <template>
+<template>
   Explicit default export module top level component. Explicit default export
   module top level component. Explicit default export module top level
   component. Explicit default export module top level component. Explicit
@@ -262,7 +262,7 @@ export interface Signature {
   Yields: [];
 }
 
-export default <template>
+<template>
   Explicit default export module top level component. Explicit default export
   module top level component. Explicit default export module top level
   component. Explicit default export module top level component. Explicit
@@ -323,7 +323,7 @@ export interface Signature {
 `;
 
 exports[`ambiguous > config > arrowParens: "avoid" > (oops) => {} > with semi > it formats ../cases/gjs/default-export.gjs 1`] = `
-"export default <template>
+"<template>
   Explicit default export module top level component. Explicit default export
   module top level component. Explicit default export module top level
   component. Explicit default export module top level component. Explicit
@@ -399,7 +399,7 @@ export interface Signature {
   Yields: [];
 }
 
-export default <template>
+<template>
   Explicit default export module top level component. Explicit default export
   module top level component. Explicit default export module top level
   component. Explicit default export module top level component. Explicit
@@ -584,7 +584,7 @@ export interface Signature {
   Yields: [];
 }
 
-export default <template>
+<template>
   Explicit default export module top level component. Explicit default export
   module top level component. Explicit default export module top level
   component. Explicit default export module top level component. Explicit

--- a/tests/unit-tests/ambiguous/__snapshots__/index.test.ts.snap
+++ b/tests/unit-tests/ambiguous/__snapshots__/index.test.ts.snap
@@ -1,12 +1,12 @@
 // Vitest Snapshot v1
 
 exports[`ambiguous > config > default > (oh, no) => {} > with semi > it formats ../cases/gjs/default-export.gjs 1`] = `
-"export default <template>
+"<template>
   Explicit default export module top level component. Explicit default export
   module top level component. Explicit default export module top level
   component. Explicit default export module top level component. Explicit
   default export module top level component.
-</template>
+</template>;
 (oh, no) => {};
 "
 `;
@@ -63,7 +63,7 @@ const bool = false,
 `;
 
 exports[`ambiguous > config > default > (oh, no) => {} > with semi > it formats ../cases/gjs/simple.gjs 1`] = `
-"<template>what</template>
+"<template>what</template>;
 (oh, no) => {};
 "
 `;
@@ -77,7 +77,7 @@ export interface Signature {
   Yields: [];
 }
 
-export default <template>
+<template>
   Explicit default export module top level component. Explicit default export
   module top level component. Explicit default export module top level
   component. Explicit default export module top level component. Explicit
@@ -262,7 +262,7 @@ export interface Signature {
   Yields: [];
 }
 
-export default <template>
+<template>
   Explicit default export module top level component. Explicit default export
   module top level component. Explicit default export module top level
   component. Explicit default export module top level component. Explicit
@@ -323,12 +323,12 @@ export interface Signature {
 `;
 
 exports[`ambiguous > config > default > (oops) => {} > with semi > it formats ../cases/gjs/default-export.gjs 1`] = `
-"export default <template>
+"<template>
   Explicit default export module top level component. Explicit default export
   module top level component. Explicit default export module top level
   component. Explicit default export module top level component. Explicit
   default export module top level component.
-</template>
+</template>;
 (oops) => {};
 "
 `;
@@ -385,7 +385,7 @@ const bool = false,
 `;
 
 exports[`ambiguous > config > default > (oops) => {} > with semi > it formats ../cases/gjs/simple.gjs 1`] = `
-"<template>what</template>
+"<template>what</template>;
 (oops) => {};
 "
 `;
@@ -399,7 +399,7 @@ export interface Signature {
   Yields: [];
 }
 
-export default <template>
+<template>
   Explicit default export module top level component. Explicit default export
   module top level component. Explicit default export module top level
   component. Explicit default export module top level component. Explicit
@@ -584,7 +584,7 @@ export interface Signature {
   Yields: [];
 }
 
-export default <template>
+<template>
   Explicit default export module top level component. Explicit default export
   module top level component. Explicit default export module top level
   component. Explicit default export module top level component. Explicit
@@ -645,12 +645,12 @@ export interface Signature {
 `;
 
 exports[`ambiguous > config > default > +"oops" > with semi > it formats ../cases/gjs/default-export.gjs 1`] = `
-"export default <template>
+"<template>
   Explicit default export module top level component. Explicit default export
   module top level component. Explicit default export module top level
   component. Explicit default export module top level component. Explicit
   default export module top level component.
-</template>
+</template>;
 +\\"oops\\";
 "
 `;
@@ -707,7 +707,7 @@ const bool = false,
 `;
 
 exports[`ambiguous > config > default > +"oops" > with semi > it formats ../cases/gjs/simple.gjs 1`] = `
-"<template>what</template>
+"<template>what</template>;
 +\\"oops\\";
 "
 `;
@@ -721,7 +721,7 @@ export interface Signature {
   Yields: [];
 }
 
-export default <template>
+<template>
   Explicit default export module top level component. Explicit default export
   module top level component. Explicit default export module top level
   component. Explicit default export module top level component. Explicit
@@ -897,120 +897,8 @@ export interface Signature {
 "
 `;
 
-exports[`ambiguous > config > default > +"oops" > without semi > it formats ../cases/gjs/default-export.gjs 1`] = `
-"export default <template>
-  Explicit default export module top level component. Explicit default export
-  module top level component. Explicit default export module top level
-  component. Explicit default export module top level component. Explicit
-  default export module top level component.
-</template> + \\"oops\\";
-"
-`;
-
-exports[`ambiguous > config > default > +"oops" > without semi > it formats ../cases/gjs/exported-mod-var.gjs 1`] = `
-"export const Exported =
-  <template>
-    Exported variable template. Exported variable template. Exported variable
-    template. Exported variable template. Exported variable template. Exported
-    variable template. Exported variable template.
-  </template> + \\"oops\\";
-"
-`;
-
 exports[`ambiguous > config > default > +"oops" > without semi > it formats ../cases/gjs/js-only.gjs 1`] = `
 "const num = 1 + \\"oops\\";
-"
-`;
-
-exports[`ambiguous > config > default > +"oops" > without semi > it formats ../cases/gjs/mod-var.gjs 1`] = `
-"const Private =
-  <template>
-    Private variable template. Private variable template. Private variable
-    template. Private variable template. Private variable template. Private
-    variable template. Private variable template.
-  </template> + \\"oops\\";
-"
-`;
-
-exports[`ambiguous > config > default > +"oops" > without semi > it formats ../cases/gjs/multiple-declarations.gjs 1`] = `
-"const ModVar1 = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template>,
-  ModVar2 = <template>Second module variable template.</template>,
-  num = 1 + \\"oops\\";
-
-const bool = false,
-  ModVar3 = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template>,
-  ModVar4 = <template>Second module variable template.</template> + \\"oops\\";
-"
-`;
-
-exports[`ambiguous > config > default > +"oops" > without semi > it formats ../cases/gjs/simple.gjs 1`] = `
-"<template>what</template> + \\"oops\\";
-"
-`;
-
-exports[`ambiguous > config > default > +"oops" > without semi > it formats ../cases/gts/default-export.gts 1`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
-
-export interface Signature {
-  Element: HTMLElement;
-  Args: {};
-  Yields: [];
-}
-
-export default (<template>
-  Explicit default export module top level component. Explicit default export
-  module top level component. Explicit default export module top level
-  component. Explicit default export module top level component. Explicit
-  default export module top level component.
-</template> as TemplateOnlyComponent<Signature>) + \\"oops\\";
-"
-`;
-
-exports[`ambiguous > config > default > +"oops" > without semi > it formats ../cases/gts/exported-mod-var.gts 1`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
-
-export interface Signature {
-  Element: HTMLElement;
-  Args: {};
-  Yields: [];
-}
-
-export const Exported: TemplateOnlyComponent<Signature> =
-  <template>
-    Exported variable template. Exported variable template. Exported variable
-    template. Exported variable template. Exported variable template. Exported
-    variable template. Exported variable template.
-  </template> + \\"oops\\";
-"
-`;
-
-exports[`ambiguous > config > default > +"oops" > without semi > it formats ../cases/gts/exported-mod-var-with-as.gts 1`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
-
-export interface Signature {
-  Element: HTMLElement;
-  Args: {};
-  Yields: [];
-}
-
-export const Exported =
-  (<template>
-    Exported variable template. Exported variable template. Exported variable
-    template. Exported variable template. Exported variable template. Exported
-    variable template. Exported variable template.
-  </template> as TemplateOnlyComponent<Signature>) + \\"oops\\";
 "
 `;
 
@@ -1019,132 +907,13 @@ exports[`ambiguous > config > default > +"oops" > without semi > it formats ../c
 "
 `;
 
-exports[`ambiguous > config > default > +"oops" > without semi > it formats ../cases/gts/mod-var.gts 1`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
-
-export interface Signature {
-  Element: HTMLElement;
-  Args: {};
-  Yields: [];
-}
-
-const Private: TemplateOnlyComponent<Signature> =
-  <template>
-    Private variable template. Private variable template. Private variable
-    template. Private variable template. Private variable template. Private
-    variable template. Private variable template.
-  </template> + \\"oops\\";
-"
-`;
-
-exports[`ambiguous > config > default > +"oops" > without semi > it formats ../cases/gts/mod-var-with-as.gts 1`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
-
-export interface Signature {
-  Element: HTMLElement;
-  Args: {};
-  Yields: [];
-}
-
-const Private =
-  (<template>
-    Private variable template. Private variable template. Private variable
-    template. Private variable template. Private variable template. Private
-    variable template. Private variable template.
-  </template> as TemplateOnlyComponent<Signature>) + \\"oops\\";
-"
-`;
-
-exports[`ambiguous > config > default > +"oops" > without semi > it formats ../cases/gts/multiple-declarations.gts 1`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
-
-export interface Signature {
-  Element: HTMLElement;
-  Args: {};
-  Yields: [];
-}
-
-const ModVar1: TemplateOnlyComponent<Signature> = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template>,
-  ModVar2: TemplateOnlyComponent<Signature> = <template>
-    Second module variable template.
-  </template>,
-  num = 1 + \\"oops\\";
-
-const bool: boolean = false,
-  ModVar3: TemplateOnlyComponent<Signature> = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template>,
-  ModVar4: TemplateOnlyComponent<Signature> =
-    <template>Second module variable template.</template> + \\"oops\\";
-"
-`;
-
-exports[`ambiguous > config > default > +"oops" > without semi > it formats ../cases/gts/multiple-declarations-with-as.gts 1`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
-
-export interface Signature {
-  Element: HTMLElement;
-  Args: {};
-  Yields: [];
-}
-
-const ModVar1 = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template> as TemplateOnlyComponent<Signature>,
-  ModVar2 = <template>
-    Second module variable template.
-  </template> as TemplateOnlyComponent<Signature>,
-  num = 1 + \\"oops\\";
-
-const bool: boolean = false,
-  ModVar3 = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template> as TemplateOnlyComponent<Signature>,
-  ModVar4 =
-    (<template>
-      Second module variable template.
-    </template> as TemplateOnlyComponent<Signature>) + \\"oops\\";
-"
-`;
-
-exports[`ambiguous > config > default > +"oops" > without semi > it formats ../cases/gts/simple.gts 1`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
-
-export interface Signature {
-  Element: HTMLElement;
-  Args: {};
-  Yields: [];
-}
-
-(<template>what</template> as TemplateOnlyComponent<Signature>) + \\"oops\\";
-"
-`;
-
 exports[`ambiguous > config > default > /oops/ > with semi > it formats ../cases/gjs/default-export.gjs 1`] = `
-"export default <template>
+"<template>
   Explicit default export module top level component. Explicit default export
   module top level component. Explicit default export module top level
   component. Explicit default export module top level component. Explicit
   default export module top level component.
-</template>
+</template>;
 /oops/;
 "
 `;
@@ -1201,7 +970,7 @@ const bool = false,
 `;
 
 exports[`ambiguous > config > default > /oops/ > with semi > it formats ../cases/gjs/simple.gjs 1`] = `
-"<template>what</template>
+"<template>what</template>;
 /oops/;
 "
 `;
@@ -1215,7 +984,7 @@ export interface Signature {
   Yields: [];
 }
 
-export default <template>
+<template>
   Explicit default export module top level component. Explicit default export
   module top level component. Explicit default export module top level
   component. Explicit default export module top level component. Explicit
@@ -1408,12 +1177,12 @@ class MyComponent extends Component {
 `;
 
 exports[`ambiguous > config > default > <template>oops</template> > with semi > it formats ../cases/gjs/default-export.gjs 1`] = `
-"export default <template>
+"<template>
   Explicit default export module top level component. Explicit default export
   module top level component. Explicit default export module top level
   component. Explicit default export module top level component. Explicit
   default export module top level component.
-</template>
+</template>;
 <template>oops</template>
 "
 `;
@@ -1469,7 +1238,7 @@ const bool = false,
 `;
 
 exports[`ambiguous > config > default > <template>oops</template> > with semi > it formats ../cases/gjs/simple.gjs 1`] = `
-"<template>what</template>
+"<template>what</template>;
 <template>oops</template>
 "
 `;
@@ -1507,7 +1276,7 @@ export interface Signature {
   Yields: [];
 }
 
-export default <template>
+<template>
   Explicit default export module top level component. Explicit default export
   module top level component. Explicit default export module top level
   component. Explicit default export module top level component. Explicit
@@ -1682,43 +1451,71 @@ export interface Signature {
 "
 `;
 
-exports[`ambiguous > config > default > <template>oops</template> > without semi > it formats ../cases/gjs/component-class.gjs 1`] = `
-"import Component from \\"@glimmer/component\\";
-
-/** It's a component */
-class MyComponent extends Component {
-  <template>
-    <h1>
-      Class top level template. Class top level template. Class top level
-      template. Class top level template. Class top level template.
-    </h1>
-  </template>
-  <template>oops</template>
-}
+exports[`ambiguous > config > default > <template>oops</template> > without semi > it formats ../cases/gjs/default-export.gjs 1`] = `
+"<template>
+  Explicit default export module top level component. Explicit default export
+  module top level component. Explicit default export module top level
+  component. Explicit default export module top level component. Explicit
+  default export module top level component.
+</template>
+<template>oops</template>
 "
 `;
 
-exports[`ambiguous > config > default > <template>oops</template> > without semi > it formats ../cases/gts/component-class.gts 1`] = `
-"import Component from \\"@glimmer/component\\";
+exports[`ambiguous > config > default > <template>oops</template> > without semi > it formats ../cases/gjs/exported-mod-var.gjs 1`] = `
+"export const Exported = <template>
+  Exported variable template. Exported variable template. Exported variable
+  template. Exported variable template. Exported variable template. Exported
+  variable template. Exported variable template.
+</template>;
+<template>oops</template>
+"
+`;
 
-export interface Signature {
-  Element: HTMLElement;
-  Args: {
-    myArg: string;
-  };
-  Yields: [];
-}
+exports[`ambiguous > config > default > <template>oops</template> > without semi > it formats ../cases/gjs/js-only.gjs 1`] = `
+"const num = 1;
+<template>oops</template>
+"
+`;
 
-/** It's a component */
-class MyComponent extends Component<Signature> {
-  <template>
+exports[`ambiguous > config > default > <template>oops</template> > without semi > it formats ../cases/gjs/mod-var.gjs 1`] = `
+"const Private = <template>
+  Private variable template. Private variable template. Private variable
+  template. Private variable template. Private variable template. Private
+  variable template. Private variable template.
+</template>;
+<template>oops</template>
+"
+`;
+
+exports[`ambiguous > config > default > <template>oops</template> > without semi > it formats ../cases/gjs/multiple-declarations.gjs 1`] = `
+"const ModVar1 = <template>
     <h1>
-      Class top level template. Class top level template. Class top level
-      template. Class top level template. Class top level template.
+      Module variable template. Module variable template. Module variable
+      template. Module variable template. Module variable template. Module
+      variable template. Module variable template. Module variable template.
     </h1>
-  </template>
-  <template>oops</template>
-}
+  </template>,
+  ModVar2 = <template>Second module variable template.</template>,
+  num = 1;
+<template>oops</template>
+
+const bool = false,
+  ModVar3 = <template>
+    <h1>
+      Module variable template. Module variable template. Module variable
+      template. Module variable template. Module variable template. Module
+      variable template. Module variable template. Module variable template.
+    </h1>
+  </template>,
+  ModVar4 = <template>Second module variable template.</template>;
+<template>oops</template>
+"
+`;
+
+exports[`ambiguous > config > default > <template>oops</template> > without semi > it formats ../cases/gjs/simple.gjs 1`] = `
+"<template>what</template>
+<template>oops</template>
 "
 `;
 
@@ -1731,12 +1528,30 @@ export interface Signature {
   Yields: [];
 }
 
-export default <template>
+<template>
   Explicit default export module top level component. Explicit default export
   module top level component. Explicit default export module top level
   component. Explicit default export module top level component. Explicit
   default export module top level component.
-</template> as TemplateOnlyComponent<Signature>;
+</template> as TemplateOnlyComponent<Signature>
+<template>oops</template>
+"
+`;
+
+exports[`ambiguous > config > default > <template>oops</template> > without semi > it formats ../cases/gts/exported-mod-var.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
+
+export interface Signature {
+  Element: HTMLElement;
+  Args: {};
+  Yields: [];
+}
+
+export const Exported: TemplateOnlyComponent<Signature> = <template>
+  Exported variable template. Exported variable template. Exported variable
+  template. Exported variable template. Exported variable template. Exported
+  variable template. Exported variable template.
+</template>;
 <template>oops</template>
 "
 `;
@@ -1759,6 +1574,30 @@ export const Exported = <template>
 "
 `;
 
+exports[`ambiguous > config > default > <template>oops</template> > without semi > it formats ../cases/gts/js-only.gts 1`] = `
+"const num: number = 1;
+<template>oops</template>
+"
+`;
+
+exports[`ambiguous > config > default > <template>oops</template> > without semi > it formats ../cases/gts/mod-var.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
+
+export interface Signature {
+  Element: HTMLElement;
+  Args: {};
+  Yields: [];
+}
+
+const Private: TemplateOnlyComponent<Signature> = <template>
+  Private variable template. Private variable template. Private variable
+  template. Private variable template. Private variable template. Private
+  variable template. Private variable template.
+</template>;
+<template>oops</template>
+"
+`;
+
 exports[`ambiguous > config > default > <template>oops</template> > without semi > it formats ../cases/gts/mod-var-with-as.gts 1`] = `
 "import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
 
@@ -1777,6 +1616,80 @@ const Private = <template>
 "
 `;
 
+exports[`ambiguous > config > default > <template>oops</template> > without semi > it formats ../cases/gts/multiple-declarations.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
+
+export interface Signature {
+  Element: HTMLElement;
+  Args: {};
+  Yields: [];
+}
+
+const ModVar1: TemplateOnlyComponent<Signature> = <template>
+    <h1>
+      Module variable template. Module variable template. Module variable
+      template. Module variable template. Module variable template. Module
+      variable template. Module variable template. Module variable template.
+    </h1>
+  </template>,
+  ModVar2: TemplateOnlyComponent<Signature> = <template>
+    Second module variable template.
+  </template>,
+  num = 1;
+<template>oops</template>
+
+const bool: boolean = false,
+  ModVar3: TemplateOnlyComponent<Signature> = <template>
+    <h1>
+      Module variable template. Module variable template. Module variable
+      template. Module variable template. Module variable template. Module
+      variable template. Module variable template. Module variable template.
+    </h1>
+  </template>,
+  ModVar4: TemplateOnlyComponent<Signature> = <template>
+    Second module variable template.
+  </template>;
+<template>oops</template>
+"
+`;
+
+exports[`ambiguous > config > default > <template>oops</template> > without semi > it formats ../cases/gts/multiple-declarations-with-as.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
+
+export interface Signature {
+  Element: HTMLElement;
+  Args: {};
+  Yields: [];
+}
+
+const ModVar1 = <template>
+    <h1>
+      Module variable template. Module variable template. Module variable
+      template. Module variable template. Module variable template. Module
+      variable template. Module variable template. Module variable template.
+    </h1>
+  </template> as TemplateOnlyComponent<Signature>,
+  ModVar2 = <template>
+    Second module variable template.
+  </template> as TemplateOnlyComponent<Signature>,
+  num = 1;
+<template>oops</template>
+
+const bool: boolean = false,
+  ModVar3 = <template>
+    <h1>
+      Module variable template. Module variable template. Module variable
+      template. Module variable template. Module variable template. Module
+      variable template. Module variable template. Module variable template.
+    </h1>
+  </template> as TemplateOnlyComponent<Signature>,
+  ModVar4 = <template>
+    Second module variable template.
+  </template> as TemplateOnlyComponent<Signature>;
+<template>oops</template>
+"
+`;
+
 exports[`ambiguous > config > default > <template>oops</template> > without semi > it formats ../cases/gts/simple.gts 1`] = `
 "import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
 
@@ -1786,7 +1699,7 @@ export interface Signature {
   Yields: [];
 }
 
-<template>what</template> as TemplateOnlyComponent<Signature>;
+<template>what</template> as TemplateOnlyComponent<Signature>
 <template>oops</template>
 "
 `;
@@ -1808,12 +1721,12 @@ class MyComponent extends Component {
 `;
 
 exports[`ambiguous > config > default > ["oops"] > with semi > it formats ../cases/gjs/default-export.gjs 1`] = `
-"export default <template>
+"<template>
   Explicit default export module top level component. Explicit default export
   module top level component. Explicit default export module top level
   component. Explicit default export module top level component. Explicit
   default export module top level component.
-</template>
+</template>;
 [\\"oops\\"];
 "
 `;
@@ -1870,7 +1783,7 @@ const bool = false,
 `;
 
 exports[`ambiguous > config > default > ["oops"] > with semi > it formats ../cases/gjs/simple.gjs 1`] = `
-"<template>what</template>
+"<template>what</template>;
 [\\"oops\\"];
 "
 `;
@@ -1908,7 +1821,7 @@ export interface Signature {
   Yields: [];
 }
 
-export default <template>
+<template>
   Explicit default export module top level component. Explicit default export
   module top level component. Explicit default export module top level
   component. Explicit default export module top level component. Explicit
@@ -2100,64 +2013,8 @@ class MyComponent extends Component {
 "
 `;
 
-exports[`ambiguous > config > default > ["oops"] > without semi > it formats ../cases/gjs/default-export.gjs 1`] = `
-"export default <template>
-  Explicit default export module top level component. Explicit default export
-  module top level component. Explicit default export module top level
-  component. Explicit default export module top level component. Explicit
-  default export module top level component.
-</template>[\\"oops\\"];
-"
-`;
-
-exports[`ambiguous > config > default > ["oops"] > without semi > it formats ../cases/gjs/exported-mod-var.gjs 1`] = `
-"export const Exported = <template>
-  Exported variable template. Exported variable template. Exported variable
-  template. Exported variable template. Exported variable template. Exported
-  variable template. Exported variable template.
-</template>[\\"oops\\"];
-"
-`;
-
 exports[`ambiguous > config > default > ["oops"] > without semi > it formats ../cases/gjs/js-only.gjs 1`] = `
 "const num = (1)[\\"oops\\"];
-"
-`;
-
-exports[`ambiguous > config > default > ["oops"] > without semi > it formats ../cases/gjs/mod-var.gjs 1`] = `
-"const Private = <template>
-  Private variable template. Private variable template. Private variable
-  template. Private variable template. Private variable template. Private
-  variable template. Private variable template.
-</template>[\\"oops\\"];
-"
-`;
-
-exports[`ambiguous > config > default > ["oops"] > without semi > it formats ../cases/gjs/multiple-declarations.gjs 1`] = `
-"const ModVar1 = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template>,
-  ModVar2 = <template>Second module variable template.</template>,
-  num = (1)[\\"oops\\"];
-
-const bool = false,
-  ModVar3 = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template>,
-  ModVar4 = <template>Second module variable template.</template>[\\"oops\\"];
-"
-`;
-
-exports[`ambiguous > config > default > ["oops"] > without semi > it formats ../cases/gjs/simple.gjs 1`] = `
-"<template>what</template>[\\"oops\\"];
 "
 `;
 
@@ -2194,30 +2051,13 @@ export interface Signature {
   Yields: [];
 }
 
-export default <template>
+<template>
   Explicit default export module top level component. Explicit default export
   module top level component. Explicit default export module top level
   component. Explicit default export module top level component. Explicit
   default export module top level component.
 </template> as TemplateOnlyComponent<Signature>;
 [\\"oops\\"];
-"
-`;
-
-exports[`ambiguous > config > default > ["oops"] > without semi > it formats ../cases/gts/exported-mod-var.gts 1`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
-
-export interface Signature {
-  Element: HTMLElement;
-  Args: {};
-  Yields: [];
-}
-
-export const Exported: TemplateOnlyComponent<Signature> = <template>
-  Exported variable template. Exported variable template. Exported variable
-  template. Exported variable template. Exported variable template. Exported
-  variable template. Exported variable template.
-</template>[\\"oops\\"];
 "
 `;
 
@@ -2244,23 +2084,6 @@ exports[`ambiguous > config > default > ["oops"] > without semi > it formats ../
 "
 `;
 
-exports[`ambiguous > config > default > ["oops"] > without semi > it formats ../cases/gts/mod-var.gts 1`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
-
-export interface Signature {
-  Element: HTMLElement;
-  Args: {};
-  Yields: [];
-}
-
-const Private: TemplateOnlyComponent<Signature> = <template>
-  Private variable template. Private variable template. Private variable
-  template. Private variable template. Private variable template. Private
-  variable template. Private variable template.
-</template>[\\"oops\\"];
-"
-`;
-
 exports[`ambiguous > config > default > ["oops"] > without semi > it formats ../cases/gts/mod-var-with-as.gts 1`] = `
 "import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
 
@@ -2276,41 +2099,6 @@ const Private = <template>
   variable template. Private variable template.
 </template> as TemplateOnlyComponent<Signature>;
 [\\"oops\\"];
-"
-`;
-
-exports[`ambiguous > config > default > ["oops"] > without semi > it formats ../cases/gts/multiple-declarations.gts 1`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
-
-export interface Signature {
-  Element: HTMLElement;
-  Args: {};
-  Yields: [];
-}
-
-const ModVar1: TemplateOnlyComponent<Signature> = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template>,
-  ModVar2: TemplateOnlyComponent<Signature> = <template>
-    Second module variable template.
-  </template>,
-  num = (1)[\\"oops\\"];
-
-const bool: boolean = false,
-  ModVar3: TemplateOnlyComponent<Signature> = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template>,
-  ModVar4: TemplateOnlyComponent<Signature> = <template>
-    Second module variable template.
-  </template>[\\"oops\\"];
 "
 `;
 
@@ -2365,7 +2153,7 @@ export interface Signature {
 `;
 
 exports[`ambiguous > config > default > \`oops\` > with semi > it formats ../cases/gjs/default-export.gjs 1`] = `
-"export default <template>
+"<template>
   Explicit default export module top level component. Explicit default export
   module top level component. Explicit default export module top level
   component. Explicit default export module top level component. Explicit
@@ -2441,7 +2229,7 @@ export interface Signature {
   Yields: [];
 }
 
-export default <template>
+<template>
   Explicit default export module top level component. Explicit default export
   module top level component. Explicit default export module top level
   component. Explicit default export module top level component. Explicit
@@ -2617,64 +2405,8 @@ export interface Signature {
 "
 `;
 
-exports[`ambiguous > config > default > \`oops\` > without semi > it formats ../cases/gjs/default-export.gjs 1`] = `
-"export default <template>
-  Explicit default export module top level component. Explicit default export
-  module top level component. Explicit default export module top level
-  component. Explicit default export module top level component. Explicit
-  default export module top level component.
-</template>\`oops\`;
-"
-`;
-
-exports[`ambiguous > config > default > \`oops\` > without semi > it formats ../cases/gjs/exported-mod-var.gjs 1`] = `
-"export const Exported = <template>
-  Exported variable template. Exported variable template. Exported variable
-  template. Exported variable template. Exported variable template. Exported
-  variable template. Exported variable template.
-</template>\`oops\`;
-"
-`;
-
 exports[`ambiguous > config > default > \`oops\` > without semi > it formats ../cases/gjs/js-only.gjs 1`] = `
 "const num = 1\`oops\`;
-"
-`;
-
-exports[`ambiguous > config > default > \`oops\` > without semi > it formats ../cases/gjs/mod-var.gjs 1`] = `
-"const Private = <template>
-  Private variable template. Private variable template. Private variable
-  template. Private variable template. Private variable template. Private
-  variable template. Private variable template.
-</template>\`oops\`;
-"
-`;
-
-exports[`ambiguous > config > default > \`oops\` > without semi > it formats ../cases/gjs/multiple-declarations.gjs 1`] = `
-"const ModVar1 = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template>,
-  ModVar2 = <template>Second module variable template.</template>,
-  num = 1\`oops\`;
-
-const bool = false,
-  ModVar3 = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template>,
-  ModVar4 = <template>Second module variable template.</template>\`oops\`;
-"
-`;
-
-exports[`ambiguous > config > default > \`oops\` > without semi > it formats ../cases/gjs/simple.gjs 1`] = `
-"<template>what</template>\`oops\`;
 "
 `;
 
@@ -2687,30 +2419,13 @@ export interface Signature {
   Yields: [];
 }
 
-export default <template>
+<template>
   Explicit default export module top level component. Explicit default export
   module top level component. Explicit default export module top level
   component. Explicit default export module top level component. Explicit
   default export module top level component.
 </template> as TemplateOnlyComponent<Signature>
 \`oops\`;
-"
-`;
-
-exports[`ambiguous > config > default > \`oops\` > without semi > it formats ../cases/gts/exported-mod-var.gts 1`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
-
-export interface Signature {
-  Element: HTMLElement;
-  Args: {};
-  Yields: [];
-}
-
-export const Exported: TemplateOnlyComponent<Signature> = <template>
-  Exported variable template. Exported variable template. Exported variable
-  template. Exported variable template. Exported variable template. Exported
-  variable template. Exported variable template.
-</template>\`oops\`;
 "
 `;
 
@@ -2737,23 +2452,6 @@ exports[`ambiguous > config > default > \`oops\` > without semi > it formats ../
 "
 `;
 
-exports[`ambiguous > config > default > \`oops\` > without semi > it formats ../cases/gts/mod-var.gts 1`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
-
-export interface Signature {
-  Element: HTMLElement;
-  Args: {};
-  Yields: [];
-}
-
-const Private: TemplateOnlyComponent<Signature> = <template>
-  Private variable template. Private variable template. Private variable
-  template. Private variable template. Private variable template. Private
-  variable template. Private variable template.
-</template>\`oops\`;
-"
-`;
-
 exports[`ambiguous > config > default > \`oops\` > without semi > it formats ../cases/gts/mod-var-with-as.gts 1`] = `
 "import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
 
@@ -2769,41 +2467,6 @@ const Private = <template>
   variable template. Private variable template.
 </template> as TemplateOnlyComponent<Signature>;
 \`oops\`;
-"
-`;
-
-exports[`ambiguous > config > default > \`oops\` > without semi > it formats ../cases/gts/multiple-declarations.gts 1`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
-
-export interface Signature {
-  Element: HTMLElement;
-  Args: {};
-  Yields: [];
-}
-
-const ModVar1: TemplateOnlyComponent<Signature> = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template>,
-  ModVar2: TemplateOnlyComponent<Signature> = <template>
-    Second module variable template.
-  </template>,
-  num = 1\`oops\`;
-
-const bool: boolean = false,
-  ModVar3: TemplateOnlyComponent<Signature> = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template>,
-  ModVar4: TemplateOnlyComponent<Signature> = <template>
-    Second module variable template.
-  </template>\`oops\`;
 "
 `;
 
@@ -2858,12 +2521,12 @@ export interface Signature {
 `;
 
 exports[`ambiguous > config > default > -"oops" > with semi > it formats ../cases/gjs/default-export.gjs 1`] = `
-"export default <template>
+"<template>
   Explicit default export module top level component. Explicit default export
   module top level component. Explicit default export module top level
   component. Explicit default export module top level component. Explicit
   default export module top level component.
-</template>
+</template>;
 -\\"oops\\";
 "
 `;
@@ -2920,7 +2583,7 @@ const bool = false,
 `;
 
 exports[`ambiguous > config > default > -"oops" > with semi > it formats ../cases/gjs/simple.gjs 1`] = `
-"<template>what</template>
+"<template>what</template>;
 -\\"oops\\";
 "
 `;
@@ -2934,7 +2597,7 @@ export interface Signature {
   Yields: [];
 }
 
-export default <template>
+<template>
   Explicit default export module top level component. Explicit default export
   module top level component. Explicit default export module top level
   component. Explicit default export module top level component. Explicit
@@ -3110,243 +2773,12 @@ export interface Signature {
 "
 `;
 
-exports[`ambiguous > config > default > -"oops" > without semi > it formats ../cases/gjs/default-export.gjs 1`] = `
-"export default <template>
-  Explicit default export module top level component. Explicit default export
-  module top level component. Explicit default export module top level
-  component. Explicit default export module top level component. Explicit
-  default export module top level component.
-</template> - \\"oops\\";
-"
-`;
-
-exports[`ambiguous > config > default > -"oops" > without semi > it formats ../cases/gjs/exported-mod-var.gjs 1`] = `
-"export const Exported =
-  <template>
-    Exported variable template. Exported variable template. Exported variable
-    template. Exported variable template. Exported variable template. Exported
-    variable template. Exported variable template.
-  </template> - \\"oops\\";
-"
-`;
-
 exports[`ambiguous > config > default > -"oops" > without semi > it formats ../cases/gjs/js-only.gjs 1`] = `
 "const num = 1 - \\"oops\\";
 "
 `;
 
-exports[`ambiguous > config > default > -"oops" > without semi > it formats ../cases/gjs/mod-var.gjs 1`] = `
-"const Private =
-  <template>
-    Private variable template. Private variable template. Private variable
-    template. Private variable template. Private variable template. Private
-    variable template. Private variable template.
-  </template> - \\"oops\\";
-"
-`;
-
-exports[`ambiguous > config > default > -"oops" > without semi > it formats ../cases/gjs/multiple-declarations.gjs 1`] = `
-"const ModVar1 = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template>,
-  ModVar2 = <template>Second module variable template.</template>,
-  num = 1 - \\"oops\\";
-
-const bool = false,
-  ModVar3 = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template>,
-  ModVar4 = <template>Second module variable template.</template> - \\"oops\\";
-"
-`;
-
-exports[`ambiguous > config > default > -"oops" > without semi > it formats ../cases/gjs/simple.gjs 1`] = `
-"<template>what</template> - \\"oops\\";
-"
-`;
-
-exports[`ambiguous > config > default > -"oops" > without semi > it formats ../cases/gts/default-export.gts 1`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
-
-export interface Signature {
-  Element: HTMLElement;
-  Args: {};
-  Yields: [];
-}
-
-export default (<template>
-  Explicit default export module top level component. Explicit default export
-  module top level component. Explicit default export module top level
-  component. Explicit default export module top level component. Explicit
-  default export module top level component.
-</template> as TemplateOnlyComponent<Signature>) - \\"oops\\";
-"
-`;
-
-exports[`ambiguous > config > default > -"oops" > without semi > it formats ../cases/gts/exported-mod-var.gts 1`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
-
-export interface Signature {
-  Element: HTMLElement;
-  Args: {};
-  Yields: [];
-}
-
-export const Exported: TemplateOnlyComponent<Signature> =
-  <template>
-    Exported variable template. Exported variable template. Exported variable
-    template. Exported variable template. Exported variable template. Exported
-    variable template. Exported variable template.
-  </template> - \\"oops\\";
-"
-`;
-
-exports[`ambiguous > config > default > -"oops" > without semi > it formats ../cases/gts/exported-mod-var-with-as.gts 1`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
-
-export interface Signature {
-  Element: HTMLElement;
-  Args: {};
-  Yields: [];
-}
-
-export const Exported =
-  (<template>
-    Exported variable template. Exported variable template. Exported variable
-    template. Exported variable template. Exported variable template. Exported
-    variable template. Exported variable template.
-  </template> as TemplateOnlyComponent<Signature>) - \\"oops\\";
-"
-`;
-
 exports[`ambiguous > config > default > -"oops" > without semi > it formats ../cases/gts/js-only.gts 1`] = `
 "const num: number = 1 - \\"oops\\";
-"
-`;
-
-exports[`ambiguous > config > default > -"oops" > without semi > it formats ../cases/gts/mod-var.gts 1`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
-
-export interface Signature {
-  Element: HTMLElement;
-  Args: {};
-  Yields: [];
-}
-
-const Private: TemplateOnlyComponent<Signature> =
-  <template>
-    Private variable template. Private variable template. Private variable
-    template. Private variable template. Private variable template. Private
-    variable template. Private variable template.
-  </template> - \\"oops\\";
-"
-`;
-
-exports[`ambiguous > config > default > -"oops" > without semi > it formats ../cases/gts/mod-var-with-as.gts 1`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
-
-export interface Signature {
-  Element: HTMLElement;
-  Args: {};
-  Yields: [];
-}
-
-const Private =
-  (<template>
-    Private variable template. Private variable template. Private variable
-    template. Private variable template. Private variable template. Private
-    variable template. Private variable template.
-  </template> as TemplateOnlyComponent<Signature>) - \\"oops\\";
-"
-`;
-
-exports[`ambiguous > config > default > -"oops" > without semi > it formats ../cases/gts/multiple-declarations.gts 1`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
-
-export interface Signature {
-  Element: HTMLElement;
-  Args: {};
-  Yields: [];
-}
-
-const ModVar1: TemplateOnlyComponent<Signature> = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template>,
-  ModVar2: TemplateOnlyComponent<Signature> = <template>
-    Second module variable template.
-  </template>,
-  num = 1 - \\"oops\\";
-
-const bool: boolean = false,
-  ModVar3: TemplateOnlyComponent<Signature> = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template>,
-  ModVar4: TemplateOnlyComponent<Signature> =
-    <template>Second module variable template.</template> - \\"oops\\";
-"
-`;
-
-exports[`ambiguous > config > default > -"oops" > without semi > it formats ../cases/gts/multiple-declarations-with-as.gts 1`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
-
-export interface Signature {
-  Element: HTMLElement;
-  Args: {};
-  Yields: [];
-}
-
-const ModVar1 = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template> as TemplateOnlyComponent<Signature>,
-  ModVar2 = <template>
-    Second module variable template.
-  </template> as TemplateOnlyComponent<Signature>,
-  num = 1 - \\"oops\\";
-
-const bool: boolean = false,
-  ModVar3 = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template> as TemplateOnlyComponent<Signature>,
-  ModVar4 =
-    (<template>
-      Second module variable template.
-    </template> as TemplateOnlyComponent<Signature>) - \\"oops\\";
-"
-`;
-
-exports[`ambiguous > config > default > -"oops" > without semi > it formats ../cases/gts/simple.gts 1`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
-
-export interface Signature {
-  Element: HTMLElement;
-  Args: {};
-  Yields: [];
-}
-
-(<template>what</template> as TemplateOnlyComponent<Signature>) - \\"oops\\";
 "
 `;

--- a/tests/unit-tests/ambiguous/__snapshots__/semi-false.test.ts.snap
+++ b/tests/unit-tests/ambiguous/__snapshots__/semi-false.test.ts.snap
@@ -1,7 +1,7 @@
 // Vitest Snapshot v1
 
 exports[`ambiguous > config > semi: false > (oh, no) => {} > with semi > it formats ../cases/gjs/default-export.gjs 1`] = `
-"export default <template>
+"<template>
   Explicit default export module top level component. Explicit default export
   module top level component. Explicit default export module top level
   component. Explicit default export module top level component. Explicit
@@ -77,7 +77,7 @@ export interface Signature {
   Yields: []
 }
 
-export default <template>
+<template>
   Explicit default export module top level component. Explicit default export
   module top level component. Explicit default export module top level
   component. Explicit default export module top level component. Explicit
@@ -262,7 +262,7 @@ export interface Signature {
   Yields: []
 }
 
-export default <template>
+<template>
   Explicit default export module top level component. Explicit default export
   module top level component. Explicit default export module top level
   component. Explicit default export module top level component. Explicit
@@ -323,7 +323,7 @@ export interface Signature {
 `;
 
 exports[`ambiguous > config > semi: false > (oops) => {} > with semi > it formats ../cases/gjs/default-export.gjs 1`] = `
-"export default <template>
+"<template>
   Explicit default export module top level component. Explicit default export
   module top level component. Explicit default export module top level
   component. Explicit default export module top level component. Explicit
@@ -399,7 +399,7 @@ export interface Signature {
   Yields: []
 }
 
-export default <template>
+<template>
   Explicit default export module top level component. Explicit default export
   module top level component. Explicit default export module top level
   component. Explicit default export module top level component. Explicit
@@ -584,7 +584,7 @@ export interface Signature {
   Yields: []
 }
 
-export default <template>
+<template>
   Explicit default export module top level component. Explicit default export
   module top level component. Explicit default export module top level
   component. Explicit default export module top level component. Explicit
@@ -645,7 +645,7 @@ export interface Signature {
 `;
 
 exports[`ambiguous > config > semi: false > +"oops" > with semi > it formats ../cases/gjs/default-export.gjs 1`] = `
-"export default <template>
+"<template>
   Explicit default export module top level component. Explicit default export
   module top level component. Explicit default export module top level
   component. Explicit default export module top level component. Explicit
@@ -721,7 +721,7 @@ export interface Signature {
   Yields: []
 }
 
-export default <template>
+<template>
   Explicit default export module top level component. Explicit default export
   module top level component. Explicit default export module top level
   component. Explicit default export module top level component. Explicit
@@ -897,120 +897,8 @@ export interface Signature {
 "
 `;
 
-exports[`ambiguous > config > semi: false > +"oops" > without semi > it formats ../cases/gjs/default-export.gjs 1`] = `
-"export default <template>
-  Explicit default export module top level component. Explicit default export
-  module top level component. Explicit default export module top level
-  component. Explicit default export module top level component. Explicit
-  default export module top level component.
-</template> + \\"oops\\"
-"
-`;
-
-exports[`ambiguous > config > semi: false > +"oops" > without semi > it formats ../cases/gjs/exported-mod-var.gjs 1`] = `
-"export const Exported =
-  <template>
-    Exported variable template. Exported variable template. Exported variable
-    template. Exported variable template. Exported variable template. Exported
-    variable template. Exported variable template.
-  </template> + \\"oops\\"
-"
-`;
-
 exports[`ambiguous > config > semi: false > +"oops" > without semi > it formats ../cases/gjs/js-only.gjs 1`] = `
 "const num = 1 + \\"oops\\"
-"
-`;
-
-exports[`ambiguous > config > semi: false > +"oops" > without semi > it formats ../cases/gjs/mod-var.gjs 1`] = `
-"const Private =
-  <template>
-    Private variable template. Private variable template. Private variable
-    template. Private variable template. Private variable template. Private
-    variable template. Private variable template.
-  </template> + \\"oops\\"
-"
-`;
-
-exports[`ambiguous > config > semi: false > +"oops" > without semi > it formats ../cases/gjs/multiple-declarations.gjs 1`] = `
-"const ModVar1 = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template>,
-  ModVar2 = <template>Second module variable template.</template>,
-  num = 1 + \\"oops\\"
-
-const bool = false,
-  ModVar3 = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template>,
-  ModVar4 = <template>Second module variable template.</template> + \\"oops\\"
-"
-`;
-
-exports[`ambiguous > config > semi: false > +"oops" > without semi > it formats ../cases/gjs/simple.gjs 1`] = `
-"<template>what</template> + \\"oops\\"
-"
-`;
-
-exports[`ambiguous > config > semi: false > +"oops" > without semi > it formats ../cases/gts/default-export.gts 1`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
-
-export interface Signature {
-  Element: HTMLElement
-  Args: {}
-  Yields: []
-}
-
-export default (<template>
-  Explicit default export module top level component. Explicit default export
-  module top level component. Explicit default export module top level
-  component. Explicit default export module top level component. Explicit
-  default export module top level component.
-</template> as TemplateOnlyComponent<Signature>) + \\"oops\\"
-"
-`;
-
-exports[`ambiguous > config > semi: false > +"oops" > without semi > it formats ../cases/gts/exported-mod-var.gts 1`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
-
-export interface Signature {
-  Element: HTMLElement
-  Args: {}
-  Yields: []
-}
-
-export const Exported: TemplateOnlyComponent<Signature> =
-  <template>
-    Exported variable template. Exported variable template. Exported variable
-    template. Exported variable template. Exported variable template. Exported
-    variable template. Exported variable template.
-  </template> + \\"oops\\"
-"
-`;
-
-exports[`ambiguous > config > semi: false > +"oops" > without semi > it formats ../cases/gts/exported-mod-var-with-as.gts 1`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
-
-export interface Signature {
-  Element: HTMLElement
-  Args: {}
-  Yields: []
-}
-
-export const Exported =
-  (<template>
-    Exported variable template. Exported variable template. Exported variable
-    template. Exported variable template. Exported variable template. Exported
-    variable template. Exported variable template.
-  </template> as TemplateOnlyComponent<Signature>) + \\"oops\\"
 "
 `;
 
@@ -1019,127 +907,8 @@ exports[`ambiguous > config > semi: false > +"oops" > without semi > it formats 
 "
 `;
 
-exports[`ambiguous > config > semi: false > +"oops" > without semi > it formats ../cases/gts/mod-var.gts 1`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
-
-export interface Signature {
-  Element: HTMLElement
-  Args: {}
-  Yields: []
-}
-
-const Private: TemplateOnlyComponent<Signature> =
-  <template>
-    Private variable template. Private variable template. Private variable
-    template. Private variable template. Private variable template. Private
-    variable template. Private variable template.
-  </template> + \\"oops\\"
-"
-`;
-
-exports[`ambiguous > config > semi: false > +"oops" > without semi > it formats ../cases/gts/mod-var-with-as.gts 1`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
-
-export interface Signature {
-  Element: HTMLElement
-  Args: {}
-  Yields: []
-}
-
-const Private =
-  (<template>
-    Private variable template. Private variable template. Private variable
-    template. Private variable template. Private variable template. Private
-    variable template. Private variable template.
-  </template> as TemplateOnlyComponent<Signature>) + \\"oops\\"
-"
-`;
-
-exports[`ambiguous > config > semi: false > +"oops" > without semi > it formats ../cases/gts/multiple-declarations.gts 1`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
-
-export interface Signature {
-  Element: HTMLElement
-  Args: {}
-  Yields: []
-}
-
-const ModVar1: TemplateOnlyComponent<Signature> = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template>,
-  ModVar2: TemplateOnlyComponent<Signature> = <template>
-    Second module variable template.
-  </template>,
-  num = 1 + \\"oops\\"
-
-const bool: boolean = false,
-  ModVar3: TemplateOnlyComponent<Signature> = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template>,
-  ModVar4: TemplateOnlyComponent<Signature> =
-    <template>Second module variable template.</template> + \\"oops\\"
-"
-`;
-
-exports[`ambiguous > config > semi: false > +"oops" > without semi > it formats ../cases/gts/multiple-declarations-with-as.gts 1`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
-
-export interface Signature {
-  Element: HTMLElement
-  Args: {}
-  Yields: []
-}
-
-const ModVar1 = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template> as TemplateOnlyComponent<Signature>,
-  ModVar2 = <template>
-    Second module variable template.
-  </template> as TemplateOnlyComponent<Signature>,
-  num = 1 + \\"oops\\"
-
-const bool: boolean = false,
-  ModVar3 = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template> as TemplateOnlyComponent<Signature>,
-  ModVar4 =
-    (<template>
-      Second module variable template.
-    </template> as TemplateOnlyComponent<Signature>) + \\"oops\\"
-"
-`;
-
-exports[`ambiguous > config > semi: false > +"oops" > without semi > it formats ../cases/gts/simple.gts 1`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
-
-export interface Signature {
-  Element: HTMLElement
-  Args: {}
-  Yields: []
-}
-
-;(<template>what</template> as TemplateOnlyComponent<Signature>) + \\"oops\\"
-"
-`;
-
 exports[`ambiguous > config > semi: false > /oops/ > with semi > it formats ../cases/gjs/default-export.gjs 1`] = `
-"export default <template>
+"<template>
   Explicit default export module top level component. Explicit default export
   module top level component. Explicit default export module top level
   component. Explicit default export module top level component. Explicit
@@ -1215,7 +984,7 @@ export interface Signature {
   Yields: []
 }
 
-export default <template>
+<template>
   Explicit default export module top level component. Explicit default export
   module top level component. Explicit default export module top level
   component. Explicit default export module top level component. Explicit
@@ -1408,7 +1177,7 @@ class MyComponent extends Component {
 `;
 
 exports[`ambiguous > config > semi: false > <template>oops</template> > with semi > it formats ../cases/gjs/default-export.gjs 1`] = `
-"export default <template>
+"<template>
   Explicit default export module top level component. Explicit default export
   module top level component. Explicit default export module top level
   component. Explicit default export module top level component. Explicit
@@ -1507,7 +1276,7 @@ export interface Signature {
   Yields: []
 }
 
-export default <template>
+<template>
   Explicit default export module top level component. Explicit default export
   module top level component. Explicit default export module top level
   component. Explicit default export module top level component. Explicit
@@ -1682,43 +1451,71 @@ export interface Signature {
 "
 `;
 
-exports[`ambiguous > config > semi: false > <template>oops</template> > without semi > it formats ../cases/gjs/component-class.gjs 1`] = `
-"import Component from \\"@glimmer/component\\"
-
-/** It's a component */
-class MyComponent extends Component {
-  <template>
-    <h1>
-      Class top level template. Class top level template. Class top level
-      template. Class top level template. Class top level template.
-    </h1>
-  </template>
-  <template>oops</template>
-}
+exports[`ambiguous > config > semi: false > <template>oops</template> > without semi > it formats ../cases/gjs/default-export.gjs 1`] = `
+"<template>
+  Explicit default export module top level component. Explicit default export
+  module top level component. Explicit default export module top level
+  component. Explicit default export module top level component. Explicit
+  default export module top level component.
+</template>
+<template>oops</template>
 "
 `;
 
-exports[`ambiguous > config > semi: false > <template>oops</template> > without semi > it formats ../cases/gts/component-class.gts 1`] = `
-"import Component from \\"@glimmer/component\\"
+exports[`ambiguous > config > semi: false > <template>oops</template> > without semi > it formats ../cases/gjs/exported-mod-var.gjs 1`] = `
+"export const Exported = <template>
+  Exported variable template. Exported variable template. Exported variable
+  template. Exported variable template. Exported variable template. Exported
+  variable template. Exported variable template.
+</template>
+<template>oops</template>
+"
+`;
 
-export interface Signature {
-  Element: HTMLElement
-  Args: {
-    myArg: string
-  }
-  Yields: []
-}
+exports[`ambiguous > config > semi: false > <template>oops</template> > without semi > it formats ../cases/gjs/js-only.gjs 1`] = `
+"const num = 1
+<template>oops</template>
+"
+`;
 
-/** It's a component */
-class MyComponent extends Component<Signature> {
-  <template>
+exports[`ambiguous > config > semi: false > <template>oops</template> > without semi > it formats ../cases/gjs/mod-var.gjs 1`] = `
+"const Private = <template>
+  Private variable template. Private variable template. Private variable
+  template. Private variable template. Private variable template. Private
+  variable template. Private variable template.
+</template>
+<template>oops</template>
+"
+`;
+
+exports[`ambiguous > config > semi: false > <template>oops</template> > without semi > it formats ../cases/gjs/multiple-declarations.gjs 1`] = `
+"const ModVar1 = <template>
     <h1>
-      Class top level template. Class top level template. Class top level
-      template. Class top level template. Class top level template.
+      Module variable template. Module variable template. Module variable
+      template. Module variable template. Module variable template. Module
+      variable template. Module variable template. Module variable template.
     </h1>
-  </template>
-  <template>oops</template>
-}
+  </template>,
+  ModVar2 = <template>Second module variable template.</template>,
+  num = 1
+<template>oops</template>
+
+const bool = false,
+  ModVar3 = <template>
+    <h1>
+      Module variable template. Module variable template. Module variable
+      template. Module variable template. Module variable template. Module
+      variable template. Module variable template. Module variable template.
+    </h1>
+  </template>,
+  ModVar4 = <template>Second module variable template.</template>
+<template>oops</template>
+"
+`;
+
+exports[`ambiguous > config > semi: false > <template>oops</template> > without semi > it formats ../cases/gjs/simple.gjs 1`] = `
+"<template>what</template>
+<template>oops</template>
 "
 `;
 
@@ -1731,12 +1528,30 @@ export interface Signature {
   Yields: []
 }
 
-export default <template>
+<template>
   Explicit default export module top level component. Explicit default export
   module top level component. Explicit default export module top level
   component. Explicit default export module top level component. Explicit
   default export module top level component.
 </template> as TemplateOnlyComponent<Signature>
+<template>oops</template>
+"
+`;
+
+exports[`ambiguous > config > semi: false > <template>oops</template> > without semi > it formats ../cases/gts/exported-mod-var.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
+
+export interface Signature {
+  Element: HTMLElement
+  Args: {}
+  Yields: []
+}
+
+export const Exported: TemplateOnlyComponent<Signature> = <template>
+  Exported variable template. Exported variable template. Exported variable
+  template. Exported variable template. Exported variable template. Exported
+  variable template. Exported variable template.
+</template>
 <template>oops</template>
 "
 `;
@@ -1759,6 +1574,30 @@ export const Exported = <template>
 "
 `;
 
+exports[`ambiguous > config > semi: false > <template>oops</template> > without semi > it formats ../cases/gts/js-only.gts 1`] = `
+"const num: number = 1
+<template>oops</template>
+"
+`;
+
+exports[`ambiguous > config > semi: false > <template>oops</template> > without semi > it formats ../cases/gts/mod-var.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
+
+export interface Signature {
+  Element: HTMLElement
+  Args: {}
+  Yields: []
+}
+
+const Private: TemplateOnlyComponent<Signature> = <template>
+  Private variable template. Private variable template. Private variable
+  template. Private variable template. Private variable template. Private
+  variable template. Private variable template.
+</template>
+<template>oops</template>
+"
+`;
+
 exports[`ambiguous > config > semi: false > <template>oops</template> > without semi > it formats ../cases/gts/mod-var-with-as.gts 1`] = `
 "import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
 
@@ -1773,6 +1612,80 @@ const Private = <template>
   template. Private variable template. Private variable template. Private
   variable template. Private variable template.
 </template> as TemplateOnlyComponent<Signature>
+<template>oops</template>
+"
+`;
+
+exports[`ambiguous > config > semi: false > <template>oops</template> > without semi > it formats ../cases/gts/multiple-declarations.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
+
+export interface Signature {
+  Element: HTMLElement
+  Args: {}
+  Yields: []
+}
+
+const ModVar1: TemplateOnlyComponent<Signature> = <template>
+    <h1>
+      Module variable template. Module variable template. Module variable
+      template. Module variable template. Module variable template. Module
+      variable template. Module variable template. Module variable template.
+    </h1>
+  </template>,
+  ModVar2: TemplateOnlyComponent<Signature> = <template>
+    Second module variable template.
+  </template>,
+  num = 1
+<template>oops</template>
+
+const bool: boolean = false,
+  ModVar3: TemplateOnlyComponent<Signature> = <template>
+    <h1>
+      Module variable template. Module variable template. Module variable
+      template. Module variable template. Module variable template. Module
+      variable template. Module variable template. Module variable template.
+    </h1>
+  </template>,
+  ModVar4: TemplateOnlyComponent<Signature> = <template>
+    Second module variable template.
+  </template>
+<template>oops</template>
+"
+`;
+
+exports[`ambiguous > config > semi: false > <template>oops</template> > without semi > it formats ../cases/gts/multiple-declarations-with-as.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
+
+export interface Signature {
+  Element: HTMLElement
+  Args: {}
+  Yields: []
+}
+
+const ModVar1 = <template>
+    <h1>
+      Module variable template. Module variable template. Module variable
+      template. Module variable template. Module variable template. Module
+      variable template. Module variable template. Module variable template.
+    </h1>
+  </template> as TemplateOnlyComponent<Signature>,
+  ModVar2 = <template>
+    Second module variable template.
+  </template> as TemplateOnlyComponent<Signature>,
+  num = 1
+<template>oops</template>
+
+const bool: boolean = false,
+  ModVar3 = <template>
+    <h1>
+      Module variable template. Module variable template. Module variable
+      template. Module variable template. Module variable template. Module
+      variable template. Module variable template. Module variable template.
+    </h1>
+  </template> as TemplateOnlyComponent<Signature>,
+  ModVar4 = <template>
+    Second module variable template.
+  </template> as TemplateOnlyComponent<Signature>
 <template>oops</template>
 "
 `;
@@ -1808,7 +1721,7 @@ class MyComponent extends Component {
 `;
 
 exports[`ambiguous > config > semi: false > ["oops"] > with semi > it formats ../cases/gjs/default-export.gjs 1`] = `
-"export default <template>
+"<template>
   Explicit default export module top level component. Explicit default export
   module top level component. Explicit default export module top level
   component. Explicit default export module top level component. Explicit
@@ -1908,7 +1821,7 @@ export interface Signature {
   Yields: []
 }
 
-export default <template>
+<template>
   Explicit default export module top level component. Explicit default export
   module top level component. Explicit default export module top level
   component. Explicit default export module top level component. Explicit
@@ -2100,64 +2013,8 @@ class MyComponent extends Component {
 "
 `;
 
-exports[`ambiguous > config > semi: false > ["oops"] > without semi > it formats ../cases/gjs/default-export.gjs 1`] = `
-"export default <template>
-  Explicit default export module top level component. Explicit default export
-  module top level component. Explicit default export module top level
-  component. Explicit default export module top level component. Explicit
-  default export module top level component.
-</template>[\\"oops\\"]
-"
-`;
-
-exports[`ambiguous > config > semi: false > ["oops"] > without semi > it formats ../cases/gjs/exported-mod-var.gjs 1`] = `
-"export const Exported = <template>
-  Exported variable template. Exported variable template. Exported variable
-  template. Exported variable template. Exported variable template. Exported
-  variable template. Exported variable template.
-</template>[\\"oops\\"]
-"
-`;
-
 exports[`ambiguous > config > semi: false > ["oops"] > without semi > it formats ../cases/gjs/js-only.gjs 1`] = `
 "const num = (1)[\\"oops\\"]
-"
-`;
-
-exports[`ambiguous > config > semi: false > ["oops"] > without semi > it formats ../cases/gjs/mod-var.gjs 1`] = `
-"const Private = <template>
-  Private variable template. Private variable template. Private variable
-  template. Private variable template. Private variable template. Private
-  variable template. Private variable template.
-</template>[\\"oops\\"]
-"
-`;
-
-exports[`ambiguous > config > semi: false > ["oops"] > without semi > it formats ../cases/gjs/multiple-declarations.gjs 1`] = `
-"const ModVar1 = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template>,
-  ModVar2 = <template>Second module variable template.</template>,
-  num = (1)[\\"oops\\"]
-
-const bool = false,
-  ModVar3 = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template>,
-  ModVar4 = <template>Second module variable template.</template>[\\"oops\\"]
-"
-`;
-
-exports[`ambiguous > config > semi: false > ["oops"] > without semi > it formats ../cases/gjs/simple.gjs 1`] = `
-"<template>what</template>[\\"oops\\"]
 "
 `;
 
@@ -2194,30 +2051,13 @@ export interface Signature {
   Yields: []
 }
 
-export default <template>
+<template>
   Explicit default export module top level component. Explicit default export
   module top level component. Explicit default export module top level
   component. Explicit default export module top level component. Explicit
   default export module top level component.
 </template> as TemplateOnlyComponent<Signature>
 ;[\\"oops\\"]
-"
-`;
-
-exports[`ambiguous > config > semi: false > ["oops"] > without semi > it formats ../cases/gts/exported-mod-var.gts 1`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
-
-export interface Signature {
-  Element: HTMLElement
-  Args: {}
-  Yields: []
-}
-
-export const Exported: TemplateOnlyComponent<Signature> = <template>
-  Exported variable template. Exported variable template. Exported variable
-  template. Exported variable template. Exported variable template. Exported
-  variable template. Exported variable template.
-</template>[\\"oops\\"]
 "
 `;
 
@@ -2244,23 +2084,6 @@ exports[`ambiguous > config > semi: false > ["oops"] > without semi > it formats
 "
 `;
 
-exports[`ambiguous > config > semi: false > ["oops"] > without semi > it formats ../cases/gts/mod-var.gts 1`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
-
-export interface Signature {
-  Element: HTMLElement
-  Args: {}
-  Yields: []
-}
-
-const Private: TemplateOnlyComponent<Signature> = <template>
-  Private variable template. Private variable template. Private variable
-  template. Private variable template. Private variable template. Private
-  variable template. Private variable template.
-</template>[\\"oops\\"]
-"
-`;
-
 exports[`ambiguous > config > semi: false > ["oops"] > without semi > it formats ../cases/gts/mod-var-with-as.gts 1`] = `
 "import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
 
@@ -2276,41 +2099,6 @@ const Private = <template>
   variable template. Private variable template.
 </template> as TemplateOnlyComponent<Signature>
 ;[\\"oops\\"]
-"
-`;
-
-exports[`ambiguous > config > semi: false > ["oops"] > without semi > it formats ../cases/gts/multiple-declarations.gts 1`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
-
-export interface Signature {
-  Element: HTMLElement
-  Args: {}
-  Yields: []
-}
-
-const ModVar1: TemplateOnlyComponent<Signature> = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template>,
-  ModVar2: TemplateOnlyComponent<Signature> = <template>
-    Second module variable template.
-  </template>,
-  num = (1)[\\"oops\\"]
-
-const bool: boolean = false,
-  ModVar3: TemplateOnlyComponent<Signature> = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template>,
-  ModVar4: TemplateOnlyComponent<Signature> = <template>
-    Second module variable template.
-  </template>[\\"oops\\"]
 "
 `;
 
@@ -2365,7 +2153,7 @@ export interface Signature {
 `;
 
 exports[`ambiguous > config > semi: false > \`oops\` > with semi > it formats ../cases/gjs/default-export.gjs 1`] = `
-"export default <template>
+"<template>
   Explicit default export module top level component. Explicit default export
   module top level component. Explicit default export module top level
   component. Explicit default export module top level component. Explicit
@@ -2441,7 +2229,7 @@ export interface Signature {
   Yields: []
 }
 
-export default <template>
+<template>
   Explicit default export module top level component. Explicit default export
   module top level component. Explicit default export module top level
   component. Explicit default export module top level component. Explicit
@@ -2617,64 +2405,8 @@ export interface Signature {
 "
 `;
 
-exports[`ambiguous > config > semi: false > \`oops\` > without semi > it formats ../cases/gjs/default-export.gjs 1`] = `
-"export default <template>
-  Explicit default export module top level component. Explicit default export
-  module top level component. Explicit default export module top level
-  component. Explicit default export module top level component. Explicit
-  default export module top level component.
-</template>\`oops\`
-"
-`;
-
-exports[`ambiguous > config > semi: false > \`oops\` > without semi > it formats ../cases/gjs/exported-mod-var.gjs 1`] = `
-"export const Exported = <template>
-  Exported variable template. Exported variable template. Exported variable
-  template. Exported variable template. Exported variable template. Exported
-  variable template. Exported variable template.
-</template>\`oops\`
-"
-`;
-
 exports[`ambiguous > config > semi: false > \`oops\` > without semi > it formats ../cases/gjs/js-only.gjs 1`] = `
 "const num = 1\`oops\`
-"
-`;
-
-exports[`ambiguous > config > semi: false > \`oops\` > without semi > it formats ../cases/gjs/mod-var.gjs 1`] = `
-"const Private = <template>
-  Private variable template. Private variable template. Private variable
-  template. Private variable template. Private variable template. Private
-  variable template. Private variable template.
-</template>\`oops\`
-"
-`;
-
-exports[`ambiguous > config > semi: false > \`oops\` > without semi > it formats ../cases/gjs/multiple-declarations.gjs 1`] = `
-"const ModVar1 = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template>,
-  ModVar2 = <template>Second module variable template.</template>,
-  num = 1\`oops\`
-
-const bool = false,
-  ModVar3 = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template>,
-  ModVar4 = <template>Second module variable template.</template>\`oops\`
-"
-`;
-
-exports[`ambiguous > config > semi: false > \`oops\` > without semi > it formats ../cases/gjs/simple.gjs 1`] = `
-"<template>what</template>\`oops\`
 "
 `;
 
@@ -2687,30 +2419,13 @@ export interface Signature {
   Yields: []
 }
 
-export default <template>
+<template>
   Explicit default export module top level component. Explicit default export
   module top level component. Explicit default export module top level
   component. Explicit default export module top level component. Explicit
   default export module top level component.
 </template> as TemplateOnlyComponent<Signature>
 ;\`oops\`
-"
-`;
-
-exports[`ambiguous > config > semi: false > \`oops\` > without semi > it formats ../cases/gts/exported-mod-var.gts 1`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
-
-export interface Signature {
-  Element: HTMLElement
-  Args: {}
-  Yields: []
-}
-
-export const Exported: TemplateOnlyComponent<Signature> = <template>
-  Exported variable template. Exported variable template. Exported variable
-  template. Exported variable template. Exported variable template. Exported
-  variable template. Exported variable template.
-</template>\`oops\`
 "
 `;
 
@@ -2737,23 +2452,6 @@ exports[`ambiguous > config > semi: false > \`oops\` > without semi > it formats
 "
 `;
 
-exports[`ambiguous > config > semi: false > \`oops\` > without semi > it formats ../cases/gts/mod-var.gts 1`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
-
-export interface Signature {
-  Element: HTMLElement
-  Args: {}
-  Yields: []
-}
-
-const Private: TemplateOnlyComponent<Signature> = <template>
-  Private variable template. Private variable template. Private variable
-  template. Private variable template. Private variable template. Private
-  variable template. Private variable template.
-</template>\`oops\`
-"
-`;
-
 exports[`ambiguous > config > semi: false > \`oops\` > without semi > it formats ../cases/gts/mod-var-with-as.gts 1`] = `
 "import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
 
@@ -2769,41 +2467,6 @@ const Private = <template>
   variable template. Private variable template.
 </template> as TemplateOnlyComponent<Signature>
 ;\`oops\`
-"
-`;
-
-exports[`ambiguous > config > semi: false > \`oops\` > without semi > it formats ../cases/gts/multiple-declarations.gts 1`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
-
-export interface Signature {
-  Element: HTMLElement
-  Args: {}
-  Yields: []
-}
-
-const ModVar1: TemplateOnlyComponent<Signature> = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template>,
-  ModVar2: TemplateOnlyComponent<Signature> = <template>
-    Second module variable template.
-  </template>,
-  num = 1\`oops\`
-
-const bool: boolean = false,
-  ModVar3: TemplateOnlyComponent<Signature> = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template>,
-  ModVar4: TemplateOnlyComponent<Signature> = <template>
-    Second module variable template.
-  </template>\`oops\`
 "
 `;
 
@@ -2858,7 +2521,7 @@ export interface Signature {
 `;
 
 exports[`ambiguous > config > semi: false > -"oops" > with semi > it formats ../cases/gjs/default-export.gjs 1`] = `
-"export default <template>
+"<template>
   Explicit default export module top level component. Explicit default export
   module top level component. Explicit default export module top level
   component. Explicit default export module top level component. Explicit
@@ -2934,7 +2597,7 @@ export interface Signature {
   Yields: []
 }
 
-export default <template>
+<template>
   Explicit default export module top level component. Explicit default export
   module top level component. Explicit default export module top level
   component. Explicit default export module top level component. Explicit
@@ -3110,243 +2773,12 @@ export interface Signature {
 "
 `;
 
-exports[`ambiguous > config > semi: false > -"oops" > without semi > it formats ../cases/gjs/default-export.gjs 1`] = `
-"export default <template>
-  Explicit default export module top level component. Explicit default export
-  module top level component. Explicit default export module top level
-  component. Explicit default export module top level component. Explicit
-  default export module top level component.
-</template> - \\"oops\\"
-"
-`;
-
-exports[`ambiguous > config > semi: false > -"oops" > without semi > it formats ../cases/gjs/exported-mod-var.gjs 1`] = `
-"export const Exported =
-  <template>
-    Exported variable template. Exported variable template. Exported variable
-    template. Exported variable template. Exported variable template. Exported
-    variable template. Exported variable template.
-  </template> - \\"oops\\"
-"
-`;
-
 exports[`ambiguous > config > semi: false > -"oops" > without semi > it formats ../cases/gjs/js-only.gjs 1`] = `
 "const num = 1 - \\"oops\\"
 "
 `;
 
-exports[`ambiguous > config > semi: false > -"oops" > without semi > it formats ../cases/gjs/mod-var.gjs 1`] = `
-"const Private =
-  <template>
-    Private variable template. Private variable template. Private variable
-    template. Private variable template. Private variable template. Private
-    variable template. Private variable template.
-  </template> - \\"oops\\"
-"
-`;
-
-exports[`ambiguous > config > semi: false > -"oops" > without semi > it formats ../cases/gjs/multiple-declarations.gjs 1`] = `
-"const ModVar1 = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template>,
-  ModVar2 = <template>Second module variable template.</template>,
-  num = 1 - \\"oops\\"
-
-const bool = false,
-  ModVar3 = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template>,
-  ModVar4 = <template>Second module variable template.</template> - \\"oops\\"
-"
-`;
-
-exports[`ambiguous > config > semi: false > -"oops" > without semi > it formats ../cases/gjs/simple.gjs 1`] = `
-"<template>what</template> - \\"oops\\"
-"
-`;
-
-exports[`ambiguous > config > semi: false > -"oops" > without semi > it formats ../cases/gts/default-export.gts 1`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
-
-export interface Signature {
-  Element: HTMLElement
-  Args: {}
-  Yields: []
-}
-
-export default (<template>
-  Explicit default export module top level component. Explicit default export
-  module top level component. Explicit default export module top level
-  component. Explicit default export module top level component. Explicit
-  default export module top level component.
-</template> as TemplateOnlyComponent<Signature>) - \\"oops\\"
-"
-`;
-
-exports[`ambiguous > config > semi: false > -"oops" > without semi > it formats ../cases/gts/exported-mod-var.gts 1`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
-
-export interface Signature {
-  Element: HTMLElement
-  Args: {}
-  Yields: []
-}
-
-export const Exported: TemplateOnlyComponent<Signature> =
-  <template>
-    Exported variable template. Exported variable template. Exported variable
-    template. Exported variable template. Exported variable template. Exported
-    variable template. Exported variable template.
-  </template> - \\"oops\\"
-"
-`;
-
-exports[`ambiguous > config > semi: false > -"oops" > without semi > it formats ../cases/gts/exported-mod-var-with-as.gts 1`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
-
-export interface Signature {
-  Element: HTMLElement
-  Args: {}
-  Yields: []
-}
-
-export const Exported =
-  (<template>
-    Exported variable template. Exported variable template. Exported variable
-    template. Exported variable template. Exported variable template. Exported
-    variable template. Exported variable template.
-  </template> as TemplateOnlyComponent<Signature>) - \\"oops\\"
-"
-`;
-
 exports[`ambiguous > config > semi: false > -"oops" > without semi > it formats ../cases/gts/js-only.gts 1`] = `
 "const num: number = 1 - \\"oops\\"
-"
-`;
-
-exports[`ambiguous > config > semi: false > -"oops" > without semi > it formats ../cases/gts/mod-var.gts 1`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
-
-export interface Signature {
-  Element: HTMLElement
-  Args: {}
-  Yields: []
-}
-
-const Private: TemplateOnlyComponent<Signature> =
-  <template>
-    Private variable template. Private variable template. Private variable
-    template. Private variable template. Private variable template. Private
-    variable template. Private variable template.
-  </template> - \\"oops\\"
-"
-`;
-
-exports[`ambiguous > config > semi: false > -"oops" > without semi > it formats ../cases/gts/mod-var-with-as.gts 1`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
-
-export interface Signature {
-  Element: HTMLElement
-  Args: {}
-  Yields: []
-}
-
-const Private =
-  (<template>
-    Private variable template. Private variable template. Private variable
-    template. Private variable template. Private variable template. Private
-    variable template. Private variable template.
-  </template> as TemplateOnlyComponent<Signature>) - \\"oops\\"
-"
-`;
-
-exports[`ambiguous > config > semi: false > -"oops" > without semi > it formats ../cases/gts/multiple-declarations.gts 1`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
-
-export interface Signature {
-  Element: HTMLElement
-  Args: {}
-  Yields: []
-}
-
-const ModVar1: TemplateOnlyComponent<Signature> = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template>,
-  ModVar2: TemplateOnlyComponent<Signature> = <template>
-    Second module variable template.
-  </template>,
-  num = 1 - \\"oops\\"
-
-const bool: boolean = false,
-  ModVar3: TemplateOnlyComponent<Signature> = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template>,
-  ModVar4: TemplateOnlyComponent<Signature> =
-    <template>Second module variable template.</template> - \\"oops\\"
-"
-`;
-
-exports[`ambiguous > config > semi: false > -"oops" > without semi > it formats ../cases/gts/multiple-declarations-with-as.gts 1`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
-
-export interface Signature {
-  Element: HTMLElement
-  Args: {}
-  Yields: []
-}
-
-const ModVar1 = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template> as TemplateOnlyComponent<Signature>,
-  ModVar2 = <template>
-    Second module variable template.
-  </template> as TemplateOnlyComponent<Signature>,
-  num = 1 - \\"oops\\"
-
-const bool: boolean = false,
-  ModVar3 = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template> as TemplateOnlyComponent<Signature>,
-  ModVar4 =
-    (<template>
-      Second module variable template.
-    </template> as TemplateOnlyComponent<Signature>) - \\"oops\\"
-"
-`;
-
-exports[`ambiguous > config > semi: false > -"oops" > without semi > it formats ../cases/gts/simple.gts 1`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
-
-export interface Signature {
-  Element: HTMLElement
-  Args: {}
-  Yields: []
-}
-
-;(<template>what</template> as TemplateOnlyComponent<Signature>) - \\"oops\\"
 "
 `;

--- a/tests/unit-tests/config/__snapshots__/template-export-default.test.ts.snap
+++ b/tests/unit-tests/config/__snapshots__/template-export-default.test.ts.snap
@@ -1,7 +1,7 @@
 // Vitest Snapshot v1
 
-exports[`config > semi: false > it formats ../cases/gjs/component-class.gjs 1`] = `
-"import Component from \\"@glimmer/component\\"
+exports[`config > templateExportDefault: true > it formats ../cases/gjs/component-class.gjs 1`] = `
+"import Component from \\"@glimmer/component\\";
 
 /** It's a component */
 class MyComponent extends Component {
@@ -15,8 +15,8 @@ class MyComponent extends Component {
 "
 `;
 
-exports[`config > semi: false > it formats ../cases/gjs/component-class-with-template-literal.gjs 1`] = `
-"import Component from \\"@glimmer/component\\"
+exports[`config > templateExportDefault: true > it formats ../cases/gjs/component-class-with-template-literal.gjs 1`] = `
+"import Component from \\"@glimmer/component\\";
 
 /** It's a component */
 class MyComponent extends Component {
@@ -27,13 +27,13 @@ class MyComponent extends Component {
     </h1>
   </template>
 
-  what = \`template literal that is not a template\`
+  what = \`template literal that is not a template\`;
 }
 "
 `;
 
-exports[`config > semi: false > it formats ../cases/gjs/default-export.gjs 1`] = `
-"<template>
+exports[`config > templateExportDefault: true > it formats ../cases/gjs/default-export.gjs 1`] = `
+"export default <template>
   Explicit default export module top level component. Explicit default export
   module top level component. Explicit default export module top level
   component. Explicit default export module top level component. Explicit
@@ -42,30 +42,30 @@ exports[`config > semi: false > it formats ../cases/gjs/default-export.gjs 1`] =
 "
 `;
 
-exports[`config > semi: false > it formats ../cases/gjs/exported-mod-var.gjs 1`] = `
+exports[`config > templateExportDefault: true > it formats ../cases/gjs/exported-mod-var.gjs 1`] = `
 "export const Exported = <template>
   Exported variable template. Exported variable template. Exported variable
   template. Exported variable template. Exported variable template. Exported
   variable template. Exported variable template.
-</template>
+</template>;
 "
 `;
 
-exports[`config > semi: false > it formats ../cases/gjs/js-only.gjs 1`] = `
-"const num = 1
+exports[`config > templateExportDefault: true > it formats ../cases/gjs/js-only.gjs 1`] = `
+"const num = 1;
 "
 `;
 
-exports[`config > semi: false > it formats ../cases/gjs/mod-var.gjs 1`] = `
+exports[`config > templateExportDefault: true > it formats ../cases/gjs/mod-var.gjs 1`] = `
 "const Private = <template>
   Private variable template. Private variable template. Private variable
   template. Private variable template. Private variable template. Private
   variable template. Private variable template.
-</template>
+</template>;
 "
 `;
 
-exports[`config > semi: false > it formats ../cases/gjs/multiple-declarations.gjs 1`] = `
+exports[`config > templateExportDefault: true > it formats ../cases/gjs/multiple-declarations.gjs 1`] = `
 "const ModVar1 = <template>
     <h1>
       Module variable template. Module variable template. Module variable
@@ -74,7 +74,7 @@ exports[`config > semi: false > it formats ../cases/gjs/multiple-declarations.gj
     </h1>
   </template>,
   ModVar2 = <template>Second module variable template.</template>,
-  num = 1
+  num = 1;
 
 const bool = false,
   ModVar3 = <template>
@@ -84,17 +84,17 @@ const bool = false,
       variable template. Module variable template. Module variable template.
     </h1>
   </template>,
-  ModVar4 = <template>Second module variable template.</template>
+  ModVar4 = <template>Second module variable template.</template>;
 "
 `;
 
-exports[`config > semi: false > it formats ../cases/gjs/one-line.gjs 1`] = `
-"const Oneline = <template>Module variable template (one line).</template>
+exports[`config > templateExportDefault: true > it formats ../cases/gjs/one-line.gjs 1`] = `
+"const Oneline = <template>Module variable template (one line).</template>;
 "
 `;
 
-exports[`config > semi: false > it formats ../cases/gjs/prettier-ignore/component-class.gjs 1`] = `
-"import Component from \\"@glimmer/component\\"
+exports[`config > templateExportDefault: true > it formats ../cases/gjs/prettier-ignore/component-class.gjs 1`] = `
+"import Component from \\"@glimmer/component\\";
 
 /** It's a component */
 class MyComponent extends Component {
@@ -108,8 +108,8 @@ class MyComponent extends Component {
 "
 `;
 
-exports[`config > semi: false > it formats ../cases/gjs/prettier-ignore/component-class-with-template-literal.gjs 1`] = `
-"import Component from \\"@glimmer/component\\"
+exports[`config > templateExportDefault: true > it formats ../cases/gjs/prettier-ignore/component-class-with-template-literal.gjs 1`] = `
+"import Component from \\"@glimmer/component\\";
 
 /** It's a component */
 class MyComponent extends Component {
@@ -120,30 +120,30 @@ class MyComponent extends Component {
     <h1>   Class top level template. Class top level template. Class top level template. Class top level template. Class top level template. </h1>
   </template>
 
-  what = \`template literal that is not a template\`
+  what = \`template literal that is not a template\`;
 }
 "
 `;
 
-exports[`config > semi: false > it formats ../cases/gjs/prettier-ignore/default-export.gjs 1`] = `
+exports[`config > templateExportDefault: true > it formats ../cases/gjs/prettier-ignore/default-export.gjs 1`] = `
 "// prettier-ignore
 export default <template>     Explicit default export module top level component. Explicit default export module top level component. Explicit default export module top level component. Explicit default export module top level component. Explicit default export module top level component. </template>
 "
 `;
 
-exports[`config > semi: false > it formats ../cases/gjs/prettier-ignore/exported-mod-var.gjs 1`] = `
+exports[`config > templateExportDefault: true > it formats ../cases/gjs/prettier-ignore/exported-mod-var.gjs 1`] = `
 "// prettier-ignore
 export const Exported = <template>       Exported variable template. Exported variable template.  Exported variable template.  Exported variable template.  Exported variable template. Exported variable template. Exported variable template. </template>
 "
 `;
 
-exports[`config > semi: false > it formats ../cases/gjs/prettier-ignore/js-only.gjs 1`] = `
+exports[`config > templateExportDefault: true > it formats ../cases/gjs/prettier-ignore/js-only.gjs 1`] = `
 "// prettier-ignore
 const num = 1;
 "
 `;
 
-exports[`config > semi: false > it formats ../cases/gjs/prettier-ignore/multiple-declarations.gjs 1`] = `
+exports[`config > templateExportDefault: true > it formats ../cases/gjs/prettier-ignore/multiple-declarations.gjs 1`] = `
 "// prettier-ignore
 const ModVar1 = <template>
 
@@ -165,13 +165,13 @@ ModVar4 = <template>
 "
 `;
 
-exports[`config > semi: false > it formats ../cases/gjs/prettier-ignore/one-line.gjs 1`] = `
+exports[`config > templateExportDefault: true > it formats ../cases/gjs/prettier-ignore/one-line.gjs 1`] = `
 "// prettier-ignore
 const Oneline = <template>      Module variable template (one line). </template>
 "
 `;
 
-exports[`config > semi: false > it formats ../cases/gjs/prettier-ignore/simple.gjs 1`] = `
+exports[`config > templateExportDefault: true > it formats ../cases/gjs/prettier-ignore/simple.gjs 1`] = `
 "// prettier-ignore
 <template>
               what
@@ -179,20 +179,20 @@ exports[`config > semi: false > it formats ../cases/gjs/prettier-ignore/simple.g
 "
 `;
 
-exports[`config > semi: false > it formats ../cases/gjs/simple.gjs 1`] = `
-"<template>what</template>
+exports[`config > templateExportDefault: true > it formats ../cases/gjs/simple.gjs 1`] = `
+"export default <template>what</template>
 "
 `;
 
-exports[`config > semi: false > it formats ../cases/gts/component-class.gts 1`] = `
-"import Component from \\"@glimmer/component\\"
+exports[`config > templateExportDefault: true > it formats ../cases/gts/component-class.gts 1`] = `
+"import Component from \\"@glimmer/component\\";
 
 export interface Signature {
-  Element: HTMLElement
+  Element: HTMLElement;
   Args: {
-    myArg: string
-  }
-  Yields: []
+    myArg: string;
+  };
+  Yields: [];
 }
 
 /** It's a component */
@@ -207,15 +207,15 @@ class MyComponent extends Component<Signature> {
 "
 `;
 
-exports[`config > semi: false > it formats ../cases/gts/component-class-with-template-literal.gts 1`] = `
-"import Component from \\"@glimmer/component\\"
+exports[`config > templateExportDefault: true > it formats ../cases/gts/component-class-with-template-literal.gts 1`] = `
+"import Component from \\"@glimmer/component\\";
 
 export interface Signature {
-  Element: HTMLElement
+  Element: HTMLElement;
   Args: {
-    myArg: string
-  }
-  Yields: []
+    myArg: string;
+  };
+  Yields: [];
 }
 
 /** It's a component */
@@ -228,21 +228,21 @@ class MyComponent extends Component<Signature> {
     </h1>
   </template>
 
-  what = \`template literal that is not a template\`
+  what = \`template literal that is not a template\`;
 }
 "
 `;
 
-exports[`config > semi: false > it formats ../cases/gts/default-export.gts 1`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
+exports[`config > templateExportDefault: true > it formats ../cases/gts/default-export.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
 
 export interface Signature {
-  Element: HTMLElement
-  Args: {}
-  Yields: []
+  Element: HTMLElement;
+  Args: {};
+  Yields: [];
 }
 
-<template>
+export default <template>
   Explicit default export module top level component. Explicit default export
   module top level component. Explicit default export module top level
   component. Explicit default export module top level component. Explicit
@@ -251,86 +251,86 @@ export interface Signature {
 "
 `;
 
-exports[`config > semi: false > it formats ../cases/gts/exported-mod-var.gts 1`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
+exports[`config > templateExportDefault: true > it formats ../cases/gts/exported-mod-var.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
 
 export interface Signature {
-  Element: HTMLElement
-  Args: {}
-  Yields: []
+  Element: HTMLElement;
+  Args: {};
+  Yields: [];
 }
 
 export const Exported: TemplateOnlyComponent<Signature> = <template>
   Exported variable template. Exported variable template. Exported variable
   template. Exported variable template. Exported variable template. Exported
   variable template. Exported variable template.
-</template>
+</template>;
 "
 `;
 
-exports[`config > semi: false > it formats ../cases/gts/exported-mod-var-with-as.gts 1`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
+exports[`config > templateExportDefault: true > it formats ../cases/gts/exported-mod-var-with-as.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
 
 export interface Signature {
-  Element: HTMLElement
-  Args: {}
-  Yields: []
+  Element: HTMLElement;
+  Args: {};
+  Yields: [];
 }
 
 export const Exported = <template>
   Exported variable template. Exported variable template. Exported variable
   template. Exported variable template. Exported variable template. Exported
   variable template. Exported variable template.
-</template> as TemplateOnlyComponent<Signature>
+</template> as TemplateOnlyComponent<Signature>;
 "
 `;
 
-exports[`config > semi: false > it formats ../cases/gts/js-only.gts 1`] = `
-"const num: number = 1
+exports[`config > templateExportDefault: true > it formats ../cases/gts/js-only.gts 1`] = `
+"const num: number = 1;
 "
 `;
 
-exports[`config > semi: false > it formats ../cases/gts/mod-var.gts 1`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
+exports[`config > templateExportDefault: true > it formats ../cases/gts/mod-var.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
 
 export interface Signature {
-  Element: HTMLElement
-  Args: {}
-  Yields: []
+  Element: HTMLElement;
+  Args: {};
+  Yields: [];
 }
 
 const Private: TemplateOnlyComponent<Signature> = <template>
   Private variable template. Private variable template. Private variable
   template. Private variable template. Private variable template. Private
   variable template. Private variable template.
-</template>
+</template>;
 "
 `;
 
-exports[`config > semi: false > it formats ../cases/gts/mod-var-with-as.gts 1`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
+exports[`config > templateExportDefault: true > it formats ../cases/gts/mod-var-with-as.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
 
 export interface Signature {
-  Element: HTMLElement
-  Args: {}
-  Yields: []
+  Element: HTMLElement;
+  Args: {};
+  Yields: [];
 }
 
 const Private = <template>
   Private variable template. Private variable template. Private variable
   template. Private variable template. Private variable template. Private
   variable template. Private variable template.
-</template> as TemplateOnlyComponent<Signature>
+</template> as TemplateOnlyComponent<Signature>;
 "
 `;
 
-exports[`config > semi: false > it formats ../cases/gts/multiple-declarations.gts 1`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
+exports[`config > templateExportDefault: true > it formats ../cases/gts/multiple-declarations.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
 
 export interface Signature {
-  Element: HTMLElement
-  Args: {}
-  Yields: []
+  Element: HTMLElement;
+  Args: {};
+  Yields: [];
 }
 
 const ModVar1: TemplateOnlyComponent<Signature> = <template>
@@ -343,7 +343,7 @@ const ModVar1: TemplateOnlyComponent<Signature> = <template>
   ModVar2: TemplateOnlyComponent<Signature> = <template>
     Second module variable template.
   </template>,
-  num = 1
+  num = 1;
 
 const bool: boolean = false,
   ModVar3: TemplateOnlyComponent<Signature> = <template>
@@ -355,17 +355,17 @@ const bool: boolean = false,
   </template>,
   ModVar4: TemplateOnlyComponent<Signature> = <template>
     Second module variable template.
-  </template>
+  </template>;
 "
 `;
 
-exports[`config > semi: false > it formats ../cases/gts/multiple-declarations-with-as.gts 1`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
+exports[`config > templateExportDefault: true > it formats ../cases/gts/multiple-declarations-with-as.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
 
 export interface Signature {
-  Element: HTMLElement
-  Args: {}
-  Yields: []
+  Element: HTMLElement;
+  Args: {};
+  Yields: [];
 }
 
 const ModVar1 = <template>
@@ -378,7 +378,7 @@ const ModVar1 = <template>
   ModVar2 = <template>
     Second module variable template.
   </template> as TemplateOnlyComponent<Signature>,
-  num = 1
+  num = 1;
 
 const bool: boolean = false,
   ModVar3 = <template>
@@ -390,32 +390,32 @@ const bool: boolean = false,
   </template> as TemplateOnlyComponent<Signature>,
   ModVar4 = <template>
     Second module variable template.
-  </template> as TemplateOnlyComponent<Signature>
+  </template> as TemplateOnlyComponent<Signature>;
 "
 `;
 
-exports[`config > semi: false > it formats ../cases/gts/one-line.gts 1`] = `
-"import type { TOC } from \\"@ember/component/template-only\\"
+exports[`config > templateExportDefault: true > it formats ../cases/gts/one-line.gts 1`] = `
+"import type { TOC } from \\"@ember/component/template-only\\";
 
 export interface Sig {
-  Element: HTMLElement
-  Args: {}
-  Yields: []
+  Element: HTMLElement;
+  Args: {};
+  Yields: [];
 }
 
-const Oneline = <template>One line.</template> as TOC<Sig>
+const Oneline = <template>One line.</template> as TOC<Sig>;
 "
 `;
 
-exports[`config > semi: false > it formats ../cases/gts/prettier-ignore/component-class.gts 1`] = `
-"import Component from \\"@glimmer/component\\"
+exports[`config > templateExportDefault: true > it formats ../cases/gts/prettier-ignore/component-class.gts 1`] = `
+"import Component from \\"@glimmer/component\\";
 
 export interface Signature {
-  Element: HTMLElement
+  Element: HTMLElement;
   Args: {
-    myArg: string
-  }
-  Yields: []
+    myArg: string;
+  };
+  Yields: [];
 }
 
 /** It's a component */
@@ -430,15 +430,15 @@ class MyComponent extends Component<Signature> {
 "
 `;
 
-exports[`config > semi: false > it formats ../cases/gts/prettier-ignore/component-class-with-template-literal.gts 1`] = `
-"import Component from \\"@glimmer/component\\"
+exports[`config > templateExportDefault: true > it formats ../cases/gts/prettier-ignore/component-class-with-template-literal.gts 1`] = `
+"import Component from \\"@glimmer/component\\";
 
 export interface Signature {
-  Element: HTMLElement
+  Element: HTMLElement;
   Args: {
-    myArg: string
-  }
-  Yields: []
+    myArg: string;
+  };
+  Yields: [];
 }
 
 /** It's a component */
@@ -450,31 +450,31 @@ class MyComponent extends Component<Signature> {
     <h1 ...attributes>   {{@myArg}} Class top level template. Class top level template. Class top level template. Class top level template. Class top level template. </h1>
   </template>
 
-  what = \`template literal that is not a template\`
+  what = \`template literal that is not a template\`;
 }
 "
 `;
 
-exports[`config > semi: false > it formats ../cases/gts/prettier-ignore/default-export.gts 1`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
+exports[`config > templateExportDefault: true > it formats ../cases/gts/prettier-ignore/default-export.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
 
 export interface Signature {
-  Element: HTMLElement
-  Args: {}
-  Yields: []
+  Element: HTMLElement;
+  Args: {};
+  Yields: [];
 }
 // prettier-ignore
 export default <template>     Explicit default export module top level component. Explicit default export module top level component. Explicit default export module top level component. Explicit default export module top level component. Explicit default export module top level component. </template> as TemplateOnlyComponent<Signature>
 "
 `;
 
-exports[`config > semi: false > it formats ../cases/gts/prettier-ignore/exported-mod-var.gts 1`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
+exports[`config > templateExportDefault: true > it formats ../cases/gts/prettier-ignore/exported-mod-var.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
 
 export interface Signature {
-  Element: HTMLElement
-  Args: {}
-  Yields: []
+  Element: HTMLElement;
+  Args: {};
+  Yields: [];
 }
 
 // prettier-ignore
@@ -482,13 +482,13 @@ export const Exported: TemplateOnlyComponent<Signature>     = <template>       E
 "
 `;
 
-exports[`config > semi: false > it formats ../cases/gts/prettier-ignore/exported-mod-var-with-as.gts 1`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
+exports[`config > templateExportDefault: true > it formats ../cases/gts/prettier-ignore/exported-mod-var-with-as.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
 
 export interface Signature {
-  Element: HTMLElement
-  Args: {}
-  Yields: []
+  Element: HTMLElement;
+  Args: {};
+  Yields: [];
 }
 
 // prettier-ignore
@@ -496,19 +496,19 @@ export const Exported = <template>       Exported variable template. Exported va
 "
 `;
 
-exports[`config > semi: false > it formats ../cases/gts/prettier-ignore/js-only.gts 1`] = `
+exports[`config > templateExportDefault: true > it formats ../cases/gts/prettier-ignore/js-only.gts 1`] = `
 "// prettier-ignore
 const num:   number = 1;
 "
 `;
 
-exports[`config > semi: false > it formats ../cases/gts/prettier-ignore/multiple-declarations.gts 1`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
+exports[`config > templateExportDefault: true > it formats ../cases/gts/prettier-ignore/multiple-declarations.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
 
 export interface Signature {
-  Element: HTMLElement
-  Args: {}
-  Yields: []
+  Element: HTMLElement;
+  Args: {};
+  Yields: [];
 }
 
 // prettier-ignore
@@ -532,13 +532,13 @@ ModVar4: TemplateOnlyComponent<Signature> = <template>
 "
 `;
 
-exports[`config > semi: false > it formats ../cases/gts/prettier-ignore/multiple-declarations-with-as.gts 1`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
+exports[`config > templateExportDefault: true > it formats ../cases/gts/prettier-ignore/multiple-declarations-with-as.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
 
 export interface Signature {
-  Element: HTMLElement
-  Args: {}
-  Yields: []
+  Element: HTMLElement;
+  Args: {};
+  Yields: [];
 }
 
 // prettier-ignore
@@ -562,13 +562,13 @@ ModVar4 = <template>
 "
 `;
 
-exports[`config > semi: false > it formats ../cases/gts/prettier-ignore/one-line.gts 1`] = `
-"import type { TOC } from \\"@ember/component/template-only\\"
+exports[`config > templateExportDefault: true > it formats ../cases/gts/prettier-ignore/one-line.gts 1`] = `
+"import type { TOC } from \\"@ember/component/template-only\\";
 
 export interface Sig {
-  Element: HTMLElement
-  Args: {}
-  Yields: []
+  Element: HTMLElement;
+  Args: {};
+  Yields: [];
 }
 
 // prettier-ignore
@@ -576,13 +576,13 @@ const Oneline = <template>      Module variable template (one line). </template>
 "
 `;
 
-exports[`config > semi: false > it formats ../cases/gts/prettier-ignore/simple.gts 1`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
+exports[`config > templateExportDefault: true > it formats ../cases/gts/prettier-ignore/simple.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
 
 export interface Signature {
-  Element: HTMLElement
-  Args: {}
-  Yields: []
+  Element: HTMLElement;
+  Args: {};
+  Yields: [];
 }
 
 // prettier-ignore
@@ -592,15 +592,15 @@ export interface Signature {
 "
 `;
 
-exports[`config > semi: false > it formats ../cases/gts/simple.gts 1`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
+exports[`config > templateExportDefault: true > it formats ../cases/gts/simple.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
 
 export interface Signature {
-  Element: HTMLElement
-  Args: {}
-  Yields: []
+  Element: HTMLElement;
+  Args: {};
+  Yields: [];
 }
 
-<template>what</template> as TemplateOnlyComponent<Signature>
+export default <template>what</template> as TemplateOnlyComponent<Signature>
 "
 `;

--- a/tests/unit-tests/config/template-export-default.test.ts
+++ b/tests/unit-tests/config/template-export-default.test.ts
@@ -1,0 +1,6 @@
+import { describeSuite } from '../../helpers/make-suite';
+
+describeSuite({
+  name: 'templateExportDefault: true',
+  options: { templateExportDefault: true },
+});


### PR DESCRIPTION
Also detects more syntax errors.