### PR TITLE
Print template tags on separate lines for "default" templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,63 @@ A [Prettier](https://prettier.io/) plugin for formatting [Ember template tags](h
 
 ## Opinions
 
-This plugin works by weaving together Prettier's standard [babel-ts](https://prettier.io/playground/#N4Igxg9gdgLgprEAuEBLWcBOAzAhmOAAgFkBPASQx3yOAB0pDDsIIAKASiUIGcZN0AcwA0DJgCNcmbgEFMmXKQA8UAK4BbcVgB8oqAF8GDOAA8ADhEwxCucXwVhrYADa4ePQgDFWhVOrPOcOoIMB5klPDUBIT0jMysnDFiTCmpTAD06YQAKgDyACK53JhwMKqYjLiVjqq4zoQAbnWqRAAWWHDJaYQlZRWEAOTtzs4QA10phnGCpYSSmImxqb3ljADaTACMehNMAEzChADMeqkAuslTUwwwpGZEAEpwAI4tfNl3RAC8gwDiAKLZAaEAA+gwAEv8ZPlgWCBgAFXIAZSBoMG8IAqqi4bl4dlyLkAHJI2GDADCRMJ-zJ2MG+X+ABlAf9SQNsg8ZGSWSBhCAIGYYKhoDxkKApJgIAB3eFSBAilB1SWKEW88QOADWpSRuGCDPQcGQeGcPDgqo1WrM+CEyH4LV5QS0ABNHXBHQyqoJajNvJh1LgYIKoIJkCBcKoYBAeSBWjB1M4AOqtVDwHiWghIuXJ1ANZOkENgdxR9AmqzwhSCP2Guom3kAKx4JiRQkCAEVVBB4FXjaaQJbMCWQ5ItM4ALShKNmASweOoR0wVrIAAcAAZeZOICb4wozCHJ3ASw0DbzXh24GX+fLQzwR1A4K7XVGSq9UCUy7gK7guzWQCb1KgbZgdo-s2cBtqeX49jAtgznOC5IAcID8LgqDOEIZIQOolYoPuACsUaqCa2S2PKRrfg0LSUC6sBImAAgCjIUCOkityBBB+j6EAA) and [glimmer](https://prettier.io/playground/#N4Igxg9gdgLgprEAuEACVAeAJgSwG7qFgA2AhgM7kC8AOiAjAE4CedhqAfDVOhgBYBGDsGDoYOGMTjsAvjIwB6QVx6ZcBdCQrU6AIwhZWIFe1OERhfYbOE53Reo6YFjkABoQEAA7jo5ZKCkjIwQAO4ACkEI-iikxKGkzP4euoykYADWcDAAyqQAtnAAMjhQcMgAZnHkcClpmdk5XumlAObITACutfT5unBYWANFpFCtnaStcABiEIz5pDDiY8ggpJ0wEO4gfDD5xADqfBJw5M1gcDnREvgSzKtglNulNYww4WmtC5XVPQBW5AAHjk2lIAIqdCDwH7EGoeZqMV6rVrEHD5QqMbZeRilGAHHBYGB8ZAADgADPCQjUDmkvKtsac4Iw8OUPABHSHwD7eGJrcgAWjKAwG20YcA5ODFH0m3yQVVhPRq+RwHUY3Q85FBcAhUPKct+HhgpF0+MJxKQACZDWkcKixgBhCDo0irU4AVm2nRqABVjTF5XCQHhugBJKBDWA5MA4nwAQXDORgzCkMJqciAA) parsers, so it doesn't have many opinions of its own.
+This plugin works by weaving together Prettier's standard [babel-ts](https://prettier.io/playground/#N4Igxg9gdgLgprEAuEBLWcBOAzAhmOAAgFkBPASQx3yOAB0pDDsIIAKASiUIGcZN0AcwA0DJgCNcmbgEFMmXKQA8UAK4BbcVgB8oqAF8GDOAA8ADhEwxCucXwVhrYADa4ePQgDFWhVOrPOcOoIMB5klPDUBIT0jMysnDFiTCmpTAD06YQAKgDyACK53JhwMKqYjLiVjqq4zoQAbnWqRAAWWHDJaYQlZRWEAOTtzs4QA10phnGCpYSSmImxqb3ljADaTACMehNMAEzChADMeqkAuslTUwwwpGZEAEpwAI4tfNl3RAC8gwDiAKLZAaEAA+gwAEv8ZPlgWCBgAFXIAZSBoMG8IAqqi4bl4dlyLkAHJI2GDADCRMJ-zJ2MG+X+ABlAf9SQNsg8ZGSWSBhCAIGYYKhoDxkKApJgIAB3eFSBAilB1SWKEW88QOADWpSRuGCDPQcGQeGcPDgqo1WrM+CEyH4LV5QS0ABNHXBHQyqoJajNvJh1LgYIKoIJkCBcKoYBAeSBWjB1M4AOqtVDwHiWghIuXJ1ANZOkENgdxR9AmqzwhSCP2Guom3kAKx4JiRQkCAEVVBB4FXjaaQJbMCWQ5ItM4ALShKNmASweOoR0wVrIAAcAAZeZOICb4wozCHJ3ASw0DbzXh24GX+fLQzwR1A4K7XVGSq9UCUy7gK7guzWQCb1KgbZgdo-s2cBtqeX49jAtgznOC5IAcID8LgqDOEIZIQOolYoPuACsUaqCa2S2PKRrfg0LSUC6sBImAAgCjIUCOkityBBB+j6EAA) and [glimmer](https://prettier.io/playground/#N4Igxg9gdgLgprEAuEACVAeAJgSwG7qFgA2AhgM7kC8AOiAjAE4CedhqAfDVOhgBYBGDsGDoYOGMTjsAvjIwB6QVx6ZcBdCQrU6AIwhZWIFe1OERhfYbOE53Reo6YFjkABoQEAA7jo5ZKCkjIwQAO4ACkEI-iikxKGkzP4euoykYADWcDAAyqQAtnAAMjhQcMgAZnHkcClpmdk5XumlAObITACutfT5unBYWANFpFCtnaStcABiEIz5pDDiY8ggpJ0wEO4gfDD5xADqfBJw5M1gcDnREvgSzKtglNulNYww4WmtC5XVPQBW5AAHjk2lIAIqdCDwH7EGoeZqMV6rVrEHD5QqMbZeRilGAHHBYGB8ZAADgADPCQjUDmkvKtsac4Iw8OUPABHSHwD7eGJrcgAWjKAwG20YcA5ODFH0m3yQVVhPRq+RwHUY3Q85FBcAhUPKct+HhgpF0+MJxKQACZDWkcKixgBhCDo0irU4AVm2nRqABVjTF5XCQHhugBJKBDWA5MA4nwAQXDORgzCkMJqciAA) parsers, so it doesn't have many opinions of its own. With that said, I did have to make some opinionated decisions regarding how templates are printed within the JavaScript. In general, my strategy has been to ask "What would a function do?" since functions can be used in the same positions as the `<template>` tag.
 
-With that said, I did have to make some decisions about when and where to include or omit semicolons. You can read more about and comment on my decision process [on this RFC](https://github.com/gitKrystan/prettier-plugin-ember-template-tag/issues/1).
+### Semicolons
+
+Semicolons will be included or omitted as follows:
+
+```js
+export default class MyComponent extends Component {
+  <template>Hello</template> // omit
+}
+
+<template>Hello</template> // omit
+
+export default <template>Hello</template> // omit
+
+export const MyComponent = <template>Hello</template>; // include by default, omit in no-semi mode
+```
+
+You can read more about and comment on my semicolon decision process [on this RFC](https://github.com/gitKrystan/prettier-plugin-ember-template-tag/issues/1).
+
+### New Lines
+
+Template tags will always be printed on their own line for templates that are default exports or top-level class templates. Templates used as expressions will be allowed to collapse onto a single line if they fit:
+
+```js
+import Component from '@glimmer/component';
+
+const what = <template>Used as an expression</template>;
+
+export const who = <template>Used as an expression</template>;
+
+<template>
+  The default export
+</template>
+
+class MyComponent extends Component {
+  <template>
+    Top-level class template
+  </template>
+}
+```
+
+### `export default`
+
+The following `<template>` invocations both desugar to default exports:
+
+```js
+// template-only-component.js
+
+<template>Hello</template>;
+
+// or
+
+export default <template>Hello</template>;
+```
+
+By default, this plugin will remove `export default` to print the more concise "sugared" default export template. If you would prefer to always include `export default`, you can enable the `templateExportDefault` option described below.
 
 ## Configuration
 

--- a/src/print/template.ts
+++ b/src/print/template.ts
@@ -1,15 +1,23 @@
 import type { TemplateLiteral } from '@babel/types';
-import type { doc, ParserOptions } from 'prettier';
+import type { ParserOptions } from 'prettier';
+import { doc } from 'prettier';
+import { TEMPLATE_TAG_CLOSE, TEMPLATE_TAG_OPEN } from '../config';
 
 import type { Options } from '../options';
 import { getTemplateSingleQuote } from '../options';
 import type { BaseNode } from '../types/ast';
 
+const {
+  builders: { group, hardline, indent, softline },
+} = doc;
+
 /**
- * Returns a Prettier `Doc` for the given `TemplateLiteral` that is formatted
+ * Returns a Prettier `Doc` for the given `TemplateLiteral` contents formatted
  * using Prettier's built-in glimmer parser.
+ *
+ * NOTE: The contents are not surrounded with "`"
  */
-export function printTemplateTag(
+export function printTemplateContent(
   node: TemplateLiteral,
   textToDoc: (
     text: string,
@@ -26,4 +34,33 @@ export function printTemplateTag(
     parser: 'glimmer',
     singleQuote: getTemplateSingleQuote(options),
   });
+}
+
+/**
+ * Prints the given template content as a template tag.
+ *
+ * If `useHardline` is `true`, will use Prettier's hardline builder to force
+ * each tag to print on a new line.
+ *
+ * If `useHardline` is `false`, will use Prettier's softline builder to allow
+ * the tags to print on the same line if they fit.
+ */
+export function printTemplateTag(
+  content: doc.builders.Doc,
+  useHardline: boolean
+): doc.builders.Doc {
+  const line = useHardline ? hardline : softline;
+  return group([
+    TEMPLATE_TAG_OPEN,
+    indent([line, group(content)]),
+    line,
+    TEMPLATE_TAG_CLOSE,
+  ]);
+}
+
+/** Prints the given template content as a template literal. */
+export function printTemplateLiteral(
+  content: doc.builders.Doc
+): doc.builders.Doc {
+  return group(['`', content, '`']);
 }

--- a/src/types/glimmer.ts
+++ b/src/types/glimmer.ts
@@ -38,7 +38,8 @@ export function isGlimmerTemplateLiteral(
 
 export interface GlimmerExpressionExtra {
   forceSemi: boolean;
-  hasGlimmerExpression: true;
+  isGlimmerTemplate: true;
+  isDefaultTemplate?: boolean;
   [key: string]: unknown;
 }
 
@@ -48,7 +49,7 @@ export type GlimmerExpression = GlimmerArrayExpression | GlimmerClassProperty;
 export function isGlimmerExpression(
   node: BaseNode | null | undefined
 ): node is GlimmerExpression {
-  return node?.extra?.['hasGlimmerExpression'] === true;
+  return node?.extra?.['isGlimmerTemplate'] === true;
 }
 
 export interface GlimmerArrayExpression extends RawGlimmerArrayExpression {

--- a/tests/unit-tests/__snapshots__/format.test.ts.snap
+++ b/tests/unit-tests/__snapshots__/format.test.ts.snap
@@ -246,7 +246,9 @@ exports[`format > config > default > it formats ../cases/gjs/prettier-ignore/sim
 `;
 
 exports[`format > config > default > it formats ../cases/gjs/simple.gjs 1`] = `
-"<template>what</template>
+"<template>
+  what
+</template>
 "
 `;
 
@@ -724,6 +726,8 @@ export interface Signature {
   Yields: [];
 }
 
-<template>what</template> as TemplateOnlyComponent<Signature>
+<template>
+  what
+</template> as TemplateOnlyComponent<Signature>
 "
 `;

--- a/tests/unit-tests/ambiguous/__snapshots__/arrow-parens-avoid.test.ts.snap
+++ b/tests/unit-tests/ambiguous/__snapshots__/arrow-parens-avoid.test.ts.snap
@@ -125,13 +125,17 @@ const bool = false,
 `;
 
 exports[`ambiguous > config > arrowParens: "avoid" > (oh, no) => {} > with semi, with newline > it formats ../cases/gjs/simple.gjs 1`] = `
-"<template>what</template>;
+"<template>
+  what
+</template>;
 (oh, no) => {};
 "
 `;
 
 exports[`ambiguous > config > arrowParens: "avoid" > (oh, no) => {} > with semi, with newline > it formats ../cases/gjs/simple.gjs 2`] = `
-"<template>what</template>;
+"<template>
+  what
+</template>;
 (oh, no) => {};
 "
 `;
@@ -487,7 +491,9 @@ export interface Signature {
   Yields: [];
 }
 
-<template>what</template> as TemplateOnlyComponent<Signature>;
+<template>
+  what
+</template> as TemplateOnlyComponent<Signature>;
 (oh, no) => {};
 "
 `;
@@ -501,7 +507,9 @@ export interface Signature {
   Yields: [];
 }
 
-<template>what</template> as TemplateOnlyComponent<Signature>;
+<template>
+  what
+</template> as TemplateOnlyComponent<Signature>;
 (oh, no) => {};
 "
 `;
@@ -570,7 +578,9 @@ export interface Signature {
   Yields: [];
 }
 
-<template>what</template> as TemplateOnlyComponent<Signature>;
+<template>
+  what
+</template> as TemplateOnlyComponent<Signature>;
 (oh, no) => {};
 "
 `;
@@ -635,7 +645,9 @@ export interface Signature {
   Yields: [];
 }
 
-<template>what</template> as TemplateOnlyComponent<Signature>;
+<template>
+  what
+</template> as TemplateOnlyComponent<Signature>;
 (oh, no) => {};
 "
 `;
@@ -765,13 +777,17 @@ oops => {};
 `;
 
 exports[`ambiguous > config > arrowParens: "avoid" > (oops) => {} > with semi, with newline > it formats ../cases/gjs/simple.gjs 1`] = `
-"<template>what</template>
+"<template>
+  what
+</template>
 oops => {};
 "
 `;
 
 exports[`ambiguous > config > arrowParens: "avoid" > (oops) => {} > with semi, with newline > it formats ../cases/gjs/simple.gjs 2`] = `
-"<template>what</template>
+"<template>
+  what
+</template>
 oops => {};
 "
 `;
@@ -1127,7 +1143,9 @@ export interface Signature {
   Yields: [];
 }
 
-<template>what</template> as TemplateOnlyComponent<Signature>
+<template>
+  what
+</template> as TemplateOnlyComponent<Signature>
 oops => {};
 "
 `;
@@ -1141,7 +1159,9 @@ export interface Signature {
   Yields: [];
 }
 
-<template>what</template> as TemplateOnlyComponent<Signature>
+<template>
+  what
+</template> as TemplateOnlyComponent<Signature>
 oops => {};
 "
 `;
@@ -1210,7 +1230,9 @@ export interface Signature {
   Yields: [];
 }
 
-<template>what</template> as TemplateOnlyComponent<Signature>
+<template>
+  what
+</template> as TemplateOnlyComponent<Signature>
 oops => {};
 "
 `;
@@ -1275,7 +1297,9 @@ export interface Signature {
   Yields: [];
 }
 
-<template>what</template> as TemplateOnlyComponent<Signature>
+<template>
+  what
+</template> as TemplateOnlyComponent<Signature>
 oops => {};
 "
 `;

--- a/tests/unit-tests/ambiguous/__snapshots__/index.test.ts.snap
+++ b/tests/unit-tests/ambiguous/__snapshots__/index.test.ts.snap
@@ -125,13 +125,17 @@ const bool = false,
 `;
 
 exports[`ambiguous > config > default > (oh, no) => {} > with semi, with newline > it formats ../cases/gjs/simple.gjs 1`] = `
-"<template>what</template>;
+"<template>
+  what
+</template>;
 (oh, no) => {};
 "
 `;
 
 exports[`ambiguous > config > default > (oh, no) => {} > with semi, with newline > it formats ../cases/gjs/simple.gjs 2`] = `
-"<template>what</template>;
+"<template>
+  what
+</template>;
 (oh, no) => {};
 "
 `;
@@ -487,7 +491,9 @@ export interface Signature {
   Yields: [];
 }
 
-<template>what</template> as TemplateOnlyComponent<Signature>;
+<template>
+  what
+</template> as TemplateOnlyComponent<Signature>;
 (oh, no) => {};
 "
 `;
@@ -501,7 +507,9 @@ export interface Signature {
   Yields: [];
 }
 
-<template>what</template> as TemplateOnlyComponent<Signature>;
+<template>
+  what
+</template> as TemplateOnlyComponent<Signature>;
 (oh, no) => {};
 "
 `;
@@ -570,7 +578,9 @@ export interface Signature {
   Yields: [];
 }
 
-<template>what</template> as TemplateOnlyComponent<Signature>;
+<template>
+  what
+</template> as TemplateOnlyComponent<Signature>;
 (oh, no) => {};
 "
 `;
@@ -635,7 +645,9 @@ export interface Signature {
   Yields: [];
 }
 
-<template>what</template> as TemplateOnlyComponent<Signature>;
+<template>
+  what
+</template> as TemplateOnlyComponent<Signature>;
 (oh, no) => {};
 "
 `;
@@ -765,13 +777,17 @@ const bool = false,
 `;
 
 exports[`ambiguous > config > default > (oops) => {} > with semi, with newline > it formats ../cases/gjs/simple.gjs 1`] = `
-"<template>what</template>;
+"<template>
+  what
+</template>;
 (oops) => {};
 "
 `;
 
 exports[`ambiguous > config > default > (oops) => {} > with semi, with newline > it formats ../cases/gjs/simple.gjs 2`] = `
-"<template>what</template>;
+"<template>
+  what
+</template>;
 (oops) => {};
 "
 `;
@@ -1127,7 +1143,9 @@ export interface Signature {
   Yields: [];
 }
 
-<template>what</template> as TemplateOnlyComponent<Signature>;
+<template>
+  what
+</template> as TemplateOnlyComponent<Signature>;
 (oops) => {};
 "
 `;
@@ -1141,7 +1159,9 @@ export interface Signature {
   Yields: [];
 }
 
-<template>what</template> as TemplateOnlyComponent<Signature>;
+<template>
+  what
+</template> as TemplateOnlyComponent<Signature>;
 (oops) => {};
 "
 `;
@@ -1210,7 +1230,9 @@ export interface Signature {
   Yields: [];
 }
 
-<template>what</template> as TemplateOnlyComponent<Signature>;
+<template>
+  what
+</template> as TemplateOnlyComponent<Signature>;
 (oops) => {};
 "
 `;
@@ -1275,7 +1297,9 @@ export interface Signature {
   Yields: [];
 }
 
-<template>what</template> as TemplateOnlyComponent<Signature>;
+<template>
+  what
+</template> as TemplateOnlyComponent<Signature>;
 (oops) => {};
 "
 `;
@@ -1405,13 +1429,17 @@ const bool = false,
 `;
 
 exports[`ambiguous > config > default > +"oops" > with semi, with newline > it formats ../cases/gjs/simple.gjs 1`] = `
-"<template>what</template>;
+"<template>
+  what
+</template>;
 +\\"oops\\";
 "
 `;
 
 exports[`ambiguous > config > default > +"oops" > with semi, with newline > it formats ../cases/gjs/simple.gjs 2`] = `
-"<template>what</template>;
+"<template>
+  what
+</template>;
 +\\"oops\\";
 "
 `;
@@ -1767,7 +1795,9 @@ export interface Signature {
   Yields: [];
 }
 
-<template>what</template> as TemplateOnlyComponent<Signature>;
+<template>
+  what
+</template> as TemplateOnlyComponent<Signature>;
 +\\"oops\\";
 "
 `;
@@ -1781,7 +1811,9 @@ export interface Signature {
   Yields: [];
 }
 
-<template>what</template> as TemplateOnlyComponent<Signature>;
+<template>
+  what
+</template> as TemplateOnlyComponent<Signature>;
 +\\"oops\\";
 "
 `;
@@ -1931,13 +1963,17 @@ const bool = false,
 `;
 
 exports[`ambiguous > config > default > /oops/ > with semi, with newline > it formats ../cases/gjs/simple.gjs 1`] = `
-"<template>what</template>;
+"<template>
+  what
+</template>;
 /oops/;
 "
 `;
 
 exports[`ambiguous > config > default > /oops/ > with semi, with newline > it formats ../cases/gjs/simple.gjs 2`] = `
-"<template>what</template>;
+"<template>
+  what
+</template>;
 /oops/;
 "
 `;
@@ -2293,7 +2329,9 @@ export interface Signature {
   Yields: [];
 }
 
-<template>what</template> as TemplateOnlyComponent<Signature>;
+<template>
+  what
+</template> as TemplateOnlyComponent<Signature>;
 /oops/;
 "
 `;
@@ -2307,7 +2345,9 @@ export interface Signature {
   Yields: [];
 }
 
-<template>what</template> as TemplateOnlyComponent<Signature>;
+<template>
+  what
+</template> as TemplateOnlyComponent<Signature>;
 /oops/;
 "
 `;
@@ -2323,7 +2363,9 @@ class MyComponent extends Component {
       template. Class top level template. Class top level template.
     </h1>
   </template>
-  <template>oops</template>
+  <template>
+    oops
+  </template>
 }
 "
 `;
@@ -2341,7 +2383,9 @@ class MyComponent extends Component {
       template. Class top level template. Class top level template.
     </h1>
   </template>
-  <template>oops</template>
+  <template>
+    oops
+  </template>
 }
 "
 `;
@@ -2353,7 +2397,9 @@ exports[`ambiguous > config > default > <template>oops</template> > with semi, w
   component. Explicit default export module top level component. Explicit
   default export module top level component.
 </template>
-<template>oops</template>
+<template>
+  oops
+</template>
 "
 `;
 
@@ -2364,7 +2410,9 @@ exports[`ambiguous > config > default > <template>oops</template> > with semi, w
   component. Explicit default export module top level component. Explicit
   default export module top level component.
 </template>
-<template>oops</template>
+<template>
+  oops
+</template>
 "
 `;
 
@@ -2374,7 +2422,9 @@ exports[`ambiguous > config > default > <template>oops</template> > with semi, w
   template. Exported variable template. Exported variable template. Exported
   variable template. Exported variable template.
 </template>;
-<template>oops</template>
+<template>
+  oops
+</template>
 "
 `;
 
@@ -2384,19 +2434,25 @@ exports[`ambiguous > config > default > <template>oops</template> > with semi, w
   template. Exported variable template. Exported variable template. Exported
   variable template. Exported variable template.
 </template>;
-<template>oops</template>
+<template>
+  oops
+</template>
 "
 `;
 
 exports[`ambiguous > config > default > <template>oops</template> > with semi, with newline > it formats ../cases/gjs/js-only.gjs 1`] = `
 "const num = 1;
-<template>oops</template>
+<template>
+  oops
+</template>
 "
 `;
 
 exports[`ambiguous > config > default > <template>oops</template> > with semi, with newline > it formats ../cases/gjs/js-only.gjs 2`] = `
 "const num = 1;
-<template>oops</template>
+<template>
+  oops
+</template>
 "
 `;
 
@@ -2406,7 +2462,9 @@ exports[`ambiguous > config > default > <template>oops</template> > with semi, w
   template. Private variable template. Private variable template. Private
   variable template. Private variable template.
 </template>;
-<template>oops</template>
+<template>
+  oops
+</template>
 "
 `;
 
@@ -2416,7 +2474,9 @@ exports[`ambiguous > config > default > <template>oops</template> > with semi, w
   template. Private variable template. Private variable template. Private
   variable template. Private variable template.
 </template>;
-<template>oops</template>
+<template>
+  oops
+</template>
 "
 `;
 
@@ -2430,7 +2490,9 @@ exports[`ambiguous > config > default > <template>oops</template> > with semi, w
   </template>,
   ModVar2 = <template>Second module variable template.</template>,
   num = 1;
-<template>oops</template>
+<template>
+  oops
+</template>
 
 const bool = false,
   ModVar3 = <template>
@@ -2441,7 +2503,9 @@ const bool = false,
     </h1>
   </template>,
   ModVar4 = <template>Second module variable template.</template>;
-<template>oops</template>
+<template>
+  oops
+</template>
 "
 `;
 
@@ -2455,7 +2519,9 @@ exports[`ambiguous > config > default > <template>oops</template> > with semi, w
   </template>,
   ModVar2 = <template>Second module variable template.</template>,
   num = 1;
-<template>oops</template>
+<template>
+  oops
+</template>
 const bool = false,
   ModVar3 = <template>
     <h1>
@@ -2465,19 +2531,29 @@ const bool = false,
     </h1>
   </template>,
   ModVar4 = <template>Second module variable template.</template>;
-<template>oops</template>
+<template>
+  oops
+</template>
 "
 `;
 
 exports[`ambiguous > config > default > <template>oops</template> > with semi, with newline > it formats ../cases/gjs/simple.gjs 1`] = `
-"<template>what</template>
-<template>oops</template>
+"<template>
+  what
+</template>
+<template>
+  oops
+</template>
 "
 `;
 
 exports[`ambiguous > config > default > <template>oops</template> > with semi, with newline > it formats ../cases/gjs/simple.gjs 2`] = `
-"<template>what</template>
-<template>oops</template>
+"<template>
+  what
+</template>
+<template>
+  oops
+</template>
 "
 `;
 
@@ -2500,7 +2576,9 @@ class MyComponent extends Component<Signature> {
       template. Class top level template. Class top level template.
     </h1>
   </template>
-  <template>oops</template>
+  <template>
+    oops
+  </template>
 }
 "
 `;
@@ -2520,7 +2598,9 @@ export interface Signature {
   component. Explicit default export module top level component. Explicit
   default export module top level component.
 </template> as TemplateOnlyComponent<Signature>
-<template>oops</template>
+<template>
+  oops
+</template>
 "
 `;
 
@@ -2539,7 +2619,9 @@ export interface Signature {
   component. Explicit default export module top level component. Explicit
   default export module top level component.
 </template> as TemplateOnlyComponent<Signature>
-<template>oops</template>
+<template>
+  oops
+</template>
 "
 `;
 
@@ -2557,7 +2639,9 @@ export const Exported: TemplateOnlyComponent<Signature> = <template>
   template. Exported variable template. Exported variable template. Exported
   variable template. Exported variable template.
 </template>;
-<template>oops</template>
+<template>
+  oops
+</template>
 "
 `;
 
@@ -2575,7 +2659,9 @@ export const Exported: TemplateOnlyComponent<Signature> = <template>
   template. Exported variable template. Exported variable template. Exported
   variable template. Exported variable template.
 </template>;
-<template>oops</template>
+<template>
+  oops
+</template>
 "
 `;
 
@@ -2593,7 +2679,9 @@ export const Exported = <template>
   template. Exported variable template. Exported variable template. Exported
   variable template. Exported variable template.
 </template> as TemplateOnlyComponent<Signature>;
-<template>oops</template>
+<template>
+  oops
+</template>
 "
 `;
 
@@ -2611,19 +2699,25 @@ export const Exported = <template>
   template. Exported variable template. Exported variable template. Exported
   variable template. Exported variable template.
 </template> as TemplateOnlyComponent<Signature>;
-<template>oops</template>
+<template>
+  oops
+</template>
 "
 `;
 
 exports[`ambiguous > config > default > <template>oops</template> > with semi, with newline > it formats ../cases/gts/js-only.gts 1`] = `
 "const num: number = 1;
-<template>oops</template>
+<template>
+  oops
+</template>
 "
 `;
 
 exports[`ambiguous > config > default > <template>oops</template> > with semi, with newline > it formats ../cases/gts/js-only.gts 2`] = `
 "const num: number = 1;
-<template>oops</template>
+<template>
+  oops
+</template>
 "
 `;
 
@@ -2641,7 +2735,9 @@ const Private: TemplateOnlyComponent<Signature> = <template>
   template. Private variable template. Private variable template. Private
   variable template. Private variable template.
 </template>;
-<template>oops</template>
+<template>
+  oops
+</template>
 "
 `;
 
@@ -2659,7 +2755,9 @@ const Private: TemplateOnlyComponent<Signature> = <template>
   template. Private variable template. Private variable template. Private
   variable template. Private variable template.
 </template>;
-<template>oops</template>
+<template>
+  oops
+</template>
 "
 `;
 
@@ -2677,7 +2775,9 @@ const Private = <template>
   template. Private variable template. Private variable template. Private
   variable template. Private variable template.
 </template> as TemplateOnlyComponent<Signature>;
-<template>oops</template>
+<template>
+  oops
+</template>
 "
 `;
 
@@ -2695,7 +2795,9 @@ const Private = <template>
   template. Private variable template. Private variable template. Private
   variable template. Private variable template.
 </template> as TemplateOnlyComponent<Signature>;
-<template>oops</template>
+<template>
+  oops
+</template>
 "
 `;
 
@@ -2719,7 +2821,9 @@ const ModVar1: TemplateOnlyComponent<Signature> = <template>
     Second module variable template.
   </template>,
   num = 1;
-<template>oops</template>
+<template>
+  oops
+</template>
 
 const bool: boolean = false,
   ModVar3: TemplateOnlyComponent<Signature> = <template>
@@ -2732,7 +2836,9 @@ const bool: boolean = false,
   ModVar4: TemplateOnlyComponent<Signature> = <template>
     Second module variable template.
   </template>;
-<template>oops</template>
+<template>
+  oops
+</template>
 "
 `;
 
@@ -2756,7 +2862,9 @@ const ModVar1: TemplateOnlyComponent<Signature> = <template>
     Second module variable template.
   </template>,
   num = 1;
-<template>oops</template>
+<template>
+  oops
+</template>
 const bool: boolean = false,
   ModVar3: TemplateOnlyComponent<Signature> = <template>
     <h1>
@@ -2768,7 +2876,9 @@ const bool: boolean = false,
   ModVar4: TemplateOnlyComponent<Signature> = <template>
     Second module variable template.
   </template>;
-<template>oops</template>
+<template>
+  oops
+</template>
 "
 `;
 
@@ -2792,7 +2902,9 @@ const ModVar1 = <template>
     Second module variable template.
   </template> as TemplateOnlyComponent<Signature>,
   num = 1;
-<template>oops</template>
+<template>
+  oops
+</template>
 
 const bool: boolean = false,
   ModVar3 = <template>
@@ -2805,7 +2917,9 @@ const bool: boolean = false,
   ModVar4 = <template>
     Second module variable template.
   </template> as TemplateOnlyComponent<Signature>;
-<template>oops</template>
+<template>
+  oops
+</template>
 "
 `;
 
@@ -2829,7 +2943,9 @@ const ModVar1 = <template>
     Second module variable template.
   </template> as TemplateOnlyComponent<Signature>,
   num = 1;
-<template>oops</template>
+<template>
+  oops
+</template>
 
 const bool: boolean = false,
   ModVar3 = <template>
@@ -2842,7 +2958,9 @@ const bool: boolean = false,
   ModVar4 = <template>
     Second module variable template.
   </template> as TemplateOnlyComponent<Signature>;
-<template>oops</template>
+<template>
+  oops
+</template>
 "
 `;
 
@@ -2855,8 +2973,12 @@ export interface Signature {
   Yields: [];
 }
 
-<template>what</template> as TemplateOnlyComponent<Signature>
-<template>oops</template>
+<template>
+  what
+</template> as TemplateOnlyComponent<Signature>
+<template>
+  oops
+</template>
 "
 `;
 
@@ -2869,8 +2991,12 @@ export interface Signature {
   Yields: [];
 }
 
-<template>what</template> as TemplateOnlyComponent<Signature>
-<template>oops</template>
+<template>
+  what
+</template> as TemplateOnlyComponent<Signature>
+<template>
+  oops
+</template>
 "
 `;
 
@@ -2885,7 +3011,9 @@ class MyComponent extends Component {
       template. Class top level template. Class top level template.
     </h1>
   </template>
-  <template>oops</template>
+  <template>
+    oops
+  </template>
 }
 "
 `;
@@ -2903,7 +3031,9 @@ class MyComponent extends Component {
       template. Class top level template. Class top level template.
     </h1>
   </template>
-  <template>oops</template>
+  <template>
+    oops
+  </template>
 }
 "
 `;
@@ -2915,7 +3045,9 @@ exports[`ambiguous > config > default > <template>oops</template> > without semi
   component. Explicit default export module top level component. Explicit
   default export module top level component.
 </template>
-<template>oops</template>
+<template>
+  oops
+</template>
 "
 `;
 
@@ -2925,13 +3057,17 @@ exports[`ambiguous > config > default > <template>oops</template> > without semi
   template. Exported variable template. Exported variable template. Exported
   variable template. Exported variable template.
 </template>;
-<template>oops</template>
+<template>
+  oops
+</template>
 "
 `;
 
 exports[`ambiguous > config > default > <template>oops</template> > without semi, with newline > it formats ../cases/gjs/js-only.gjs 1`] = `
 "const num = 1;
-<template>oops</template>
+<template>
+  oops
+</template>
 "
 `;
 
@@ -2941,7 +3077,9 @@ exports[`ambiguous > config > default > <template>oops</template> > without semi
   template. Private variable template. Private variable template. Private
   variable template. Private variable template.
 </template>;
-<template>oops</template>
+<template>
+  oops
+</template>
 "
 `;
 
@@ -2955,7 +3093,9 @@ exports[`ambiguous > config > default > <template>oops</template> > without semi
   </template>,
   ModVar2 = <template>Second module variable template.</template>,
   num = 1;
-<template>oops</template>
+<template>
+  oops
+</template>
 
 const bool = false,
   ModVar3 = <template>
@@ -2966,13 +3106,19 @@ const bool = false,
     </h1>
   </template>,
   ModVar4 = <template>Second module variable template.</template>;
-<template>oops</template>
+<template>
+  oops
+</template>
 "
 `;
 
 exports[`ambiguous > config > default > <template>oops</template> > without semi, with newline > it formats ../cases/gjs/simple.gjs 1`] = `
-"<template>what</template>
-<template>oops</template>
+"<template>
+  what
+</template>
+<template>
+  oops
+</template>
 "
 `;
 
@@ -2995,7 +3141,9 @@ class MyComponent extends Component<Signature> {
       template. Class top level template. Class top level template.
     </h1>
   </template>
-  <template>oops</template>
+  <template>
+    oops
+  </template>
 }
 "
 `;
@@ -3015,7 +3163,9 @@ export interface Signature {
   component. Explicit default export module top level component. Explicit
   default export module top level component.
 </template> as TemplateOnlyComponent<Signature>
-<template>oops</template>
+<template>
+  oops
+</template>
 "
 `;
 
@@ -3033,7 +3183,9 @@ export const Exported: TemplateOnlyComponent<Signature> = <template>
   template. Exported variable template. Exported variable template. Exported
   variable template. Exported variable template.
 </template>;
-<template>oops</template>
+<template>
+  oops
+</template>
 "
 `;
 
@@ -3051,13 +3203,17 @@ export const Exported = <template>
   template. Exported variable template. Exported variable template. Exported
   variable template. Exported variable template.
 </template> as TemplateOnlyComponent<Signature>;
-<template>oops</template>
+<template>
+  oops
+</template>
 "
 `;
 
 exports[`ambiguous > config > default > <template>oops</template> > without semi, with newline > it formats ../cases/gts/js-only.gts 1`] = `
 "const num: number = 1;
-<template>oops</template>
+<template>
+  oops
+</template>
 "
 `;
 
@@ -3075,7 +3231,9 @@ const Private: TemplateOnlyComponent<Signature> = <template>
   template. Private variable template. Private variable template. Private
   variable template. Private variable template.
 </template>;
-<template>oops</template>
+<template>
+  oops
+</template>
 "
 `;
 
@@ -3093,7 +3251,9 @@ const Private = <template>
   template. Private variable template. Private variable template. Private
   variable template. Private variable template.
 </template> as TemplateOnlyComponent<Signature>;
-<template>oops</template>
+<template>
+  oops
+</template>
 "
 `;
 
@@ -3117,7 +3277,9 @@ const ModVar1: TemplateOnlyComponent<Signature> = <template>
     Second module variable template.
   </template>,
   num = 1;
-<template>oops</template>
+<template>
+  oops
+</template>
 
 const bool: boolean = false,
   ModVar3: TemplateOnlyComponent<Signature> = <template>
@@ -3130,7 +3292,9 @@ const bool: boolean = false,
   ModVar4: TemplateOnlyComponent<Signature> = <template>
     Second module variable template.
   </template>;
-<template>oops</template>
+<template>
+  oops
+</template>
 "
 `;
 
@@ -3154,7 +3318,9 @@ const ModVar1 = <template>
     Second module variable template.
   </template> as TemplateOnlyComponent<Signature>,
   num = 1;
-<template>oops</template>
+<template>
+  oops
+</template>
 
 const bool: boolean = false,
   ModVar3 = <template>
@@ -3167,7 +3333,9 @@ const bool: boolean = false,
   ModVar4 = <template>
     Second module variable template.
   </template> as TemplateOnlyComponent<Signature>;
-<template>oops</template>
+<template>
+  oops
+</template>
 "
 `;
 
@@ -3180,8 +3348,12 @@ export interface Signature {
   Yields: [];
 }
 
-<template>what</template> as TemplateOnlyComponent<Signature>
-<template>oops</template>
+<template>
+  what
+</template> as TemplateOnlyComponent<Signature>
+<template>
+  oops
+</template>
 "
 `;
 
@@ -3195,7 +3367,9 @@ class MyComponent extends Component {
       template. Class top level template. Class top level template.
     </h1>
   </template>
-  <template>oops</template>
+  <template>
+    oops
+  </template>
 }
 "
 `;
@@ -3212,7 +3386,9 @@ class MyComponent extends Component {
       template. Class top level template. Class top level template.
     </h1>
   </template>
-  <template>oops</template>
+  <template>
+    oops
+  </template>
 }
 "
 `;
@@ -3224,7 +3400,9 @@ exports[`ambiguous > config > default > <template>oops</template> > without semi
   component. Explicit default export module top level component. Explicit
   default export module top level component.
 </template>
-<template>oops</template>
+<template>
+  oops
+</template>
 "
 `;
 
@@ -3234,7 +3412,9 @@ exports[`ambiguous > config > default > <template>oops</template> > without semi
   template. Exported variable template. Exported variable template. Exported
   variable template. Exported variable template.
 </template>;
-<template>oops</template>
+<template>
+  oops
+</template>
 "
 `;
 
@@ -3244,13 +3424,19 @@ exports[`ambiguous > config > default > <template>oops</template> > without semi
   template. Private variable template. Private variable template. Private
   variable template. Private variable template.
 </template>;
-<template>oops</template>
+<template>
+  oops
+</template>
 "
 `;
 
 exports[`ambiguous > config > default > <template>oops</template> > without semi, without newline > it formats ../cases/gjs/simple.gjs 1`] = `
-"<template>what</template>
-<template>oops</template>
+"<template>
+  what
+</template>
+<template>
+  oops
+</template>
 "
 `;
 
@@ -3272,7 +3458,9 @@ class MyComponent extends Component<Signature> {
       template. Class top level template. Class top level template.
     </h1>
   </template>
-  <template>oops</template>
+  <template>
+    oops
+  </template>
 }
 "
 `;
@@ -3291,7 +3479,9 @@ export interface Signature {
   component. Explicit default export module top level component. Explicit
   default export module top level component.
 </template> as TemplateOnlyComponent<Signature>
-<template>oops</template>
+<template>
+  oops
+</template>
 "
 `;
 
@@ -3308,7 +3498,9 @@ export const Exported: TemplateOnlyComponent<Signature> = <template>
   template. Exported variable template. Exported variable template. Exported
   variable template. Exported variable template.
 </template>;
-<template>oops</template>
+<template>
+  oops
+</template>
 "
 `;
 
@@ -3325,7 +3517,9 @@ export const Exported = <template>
   template. Exported variable template. Exported variable template. Exported
   variable template. Exported variable template.
 </template> as TemplateOnlyComponent<Signature>;
-<template>oops</template>
+<template>
+  oops
+</template>
 "
 `;
 
@@ -3342,7 +3536,9 @@ const Private: TemplateOnlyComponent<Signature> = <template>
   template. Private variable template. Private variable template. Private
   variable template. Private variable template.
 </template>;
-<template>oops</template>
+<template>
+  oops
+</template>
 "
 `;
 
@@ -3359,7 +3555,9 @@ const Private = <template>
   template. Private variable template. Private variable template. Private
   variable template. Private variable template.
 </template> as TemplateOnlyComponent<Signature>;
-<template>oops</template>
+<template>
+  oops
+</template>
 "
 `;
 
@@ -3371,8 +3569,12 @@ export interface Signature {
   Yields: [];
 }
 
-<template>what</template> as TemplateOnlyComponent<Signature>
-<template>oops</template>
+<template>
+  what
+</template> as TemplateOnlyComponent<Signature>
+<template>
+  oops
+</template>
 "
 `;
 
@@ -3569,13 +3771,17 @@ const bool = false,
 `;
 
 exports[`ambiguous > config > default > ["oops"] > with semi, with newline > it formats ../cases/gjs/simple.gjs 1`] = `
-"<template>what</template>;
+"<template>
+  what
+</template>;
 [\\"oops\\"];
 "
 `;
 
 exports[`ambiguous > config > default > ["oops"] > with semi, with newline > it formats ../cases/gjs/simple.gjs 2`] = `
-"<template>what</template>;
+"<template>
+  what
+</template>;
 [\\"oops\\"];
 "
 `;
@@ -3979,7 +4185,9 @@ export interface Signature {
   Yields: [];
 }
 
-<template>what</template> as TemplateOnlyComponent<Signature>;
+<template>
+  what
+</template> as TemplateOnlyComponent<Signature>;
 [\\"oops\\"];
 "
 `;
@@ -3993,7 +4201,9 @@ export interface Signature {
   Yields: [];
 }
 
-<template>what</template> as TemplateOnlyComponent<Signature>;
+<template>
+  what
+</template> as TemplateOnlyComponent<Signature>;
 [\\"oops\\"];
 "
 `;
@@ -4166,7 +4376,9 @@ export interface Signature {
   Yields: [];
 }
 
-<template>what</template> as TemplateOnlyComponent<Signature>;
+<template>
+  what
+</template> as TemplateOnlyComponent<Signature>;
 [\\"oops\\"];
 "
 `;
@@ -4331,7 +4543,9 @@ export interface Signature {
   Yields: [];
 }
 
-<template>what</template> as TemplateOnlyComponent<Signature>;
+<template>
+  what
+</template> as TemplateOnlyComponent<Signature>;
 [\\"oops\\"];
 "
 `;
@@ -4461,13 +4675,17 @@ const bool = false,
 `;
 
 exports[`ambiguous > config > default > \`oops\` > with semi, with newline > it formats ../cases/gjs/simple.gjs 1`] = `
-"<template>what</template>
+"<template>
+  what
+</template>
 \`oops\`;
 "
 `;
 
 exports[`ambiguous > config > default > \`oops\` > with semi, with newline > it formats ../cases/gjs/simple.gjs 2`] = `
-"<template>what</template>
+"<template>
+  what
+</template>
 \`oops\`;
 "
 `;
@@ -4823,7 +5041,9 @@ export interface Signature {
   Yields: [];
 }
 
-<template>what</template> as TemplateOnlyComponent<Signature>
+<template>
+  what
+</template> as TemplateOnlyComponent<Signature>
 \`oops\`;
 "
 `;
@@ -4837,7 +5057,9 @@ export interface Signature {
   Yields: [];
 }
 
-<template>what</template> as TemplateOnlyComponent<Signature>
+<template>
+  what
+</template> as TemplateOnlyComponent<Signature>
 \`oops\`;
 "
 `;
@@ -4952,7 +5174,9 @@ export interface Signature {
   Yields: [];
 }
 
-<template>what</template> as TemplateOnlyComponent<Signature>
+<template>
+  what
+</template> as TemplateOnlyComponent<Signature>
 \`oops\`;
 "
 `;
@@ -5062,7 +5286,9 @@ export interface Signature {
   Yields: [];
 }
 
-<template>what</template> as TemplateOnlyComponent<Signature>
+<template>
+  what
+</template> as TemplateOnlyComponent<Signature>
 \`oops\`;
 "
 `;
@@ -5192,13 +5418,17 @@ const bool = false,
 `;
 
 exports[`ambiguous > config > default > -"oops" > with semi, with newline > it formats ../cases/gjs/simple.gjs 1`] = `
-"<template>what</template>;
+"<template>
+  what
+</template>;
 -\\"oops\\";
 "
 `;
 
 exports[`ambiguous > config > default > -"oops" > with semi, with newline > it formats ../cases/gjs/simple.gjs 2`] = `
-"<template>what</template>;
+"<template>
+  what
+</template>;
 -\\"oops\\";
 "
 `;
@@ -5554,7 +5784,9 @@ export interface Signature {
   Yields: [];
 }
 
-<template>what</template> as TemplateOnlyComponent<Signature>;
+<template>
+  what
+</template> as TemplateOnlyComponent<Signature>;
 -\\"oops\\";
 "
 `;
@@ -5568,7 +5800,9 @@ export interface Signature {
   Yields: [];
 }
 
-<template>what</template> as TemplateOnlyComponent<Signature>;
+<template>
+  what
+</template> as TemplateOnlyComponent<Signature>;
 -\\"oops\\";
 "
 `;

--- a/tests/unit-tests/ambiguous/__snapshots__/semi-false.test.ts.snap
+++ b/tests/unit-tests/ambiguous/__snapshots__/semi-false.test.ts.snap
@@ -125,13 +125,17 @@ const bool = false,
 `;
 
 exports[`ambiguous > config > semi: false > (oh, no) => {} > with semi, with newline > it formats ../cases/gjs/simple.gjs 1`] = `
-"<template>what</template>
+"<template>
+  what
+</template>
 ;(oh, no) => {}
 "
 `;
 
 exports[`ambiguous > config > semi: false > (oh, no) => {} > with semi, with newline > it formats ../cases/gjs/simple.gjs 2`] = `
-"<template>what</template>
+"<template>
+  what
+</template>
 ;(oh, no) => {}
 "
 `;
@@ -487,7 +491,9 @@ export interface Signature {
   Yields: []
 }
 
-<template>what</template> as TemplateOnlyComponent<Signature>
+<template>
+  what
+</template> as TemplateOnlyComponent<Signature>
 ;(oh, no) => {}
 "
 `;
@@ -501,7 +507,9 @@ export interface Signature {
   Yields: []
 }
 
-<template>what</template> as TemplateOnlyComponent<Signature>
+<template>
+  what
+</template> as TemplateOnlyComponent<Signature>
 ;(oh, no) => {}
 "
 `;
@@ -570,7 +578,9 @@ export interface Signature {
   Yields: []
 }
 
-<template>what</template> as TemplateOnlyComponent<Signature>
+<template>
+  what
+</template> as TemplateOnlyComponent<Signature>
 ;(oh, no) => {}
 "
 `;
@@ -635,7 +645,9 @@ export interface Signature {
   Yields: []
 }
 
-<template>what</template> as TemplateOnlyComponent<Signature>
+<template>
+  what
+</template> as TemplateOnlyComponent<Signature>
 ;(oh, no) => {}
 "
 `;
@@ -765,13 +777,17 @@ const bool = false,
 `;
 
 exports[`ambiguous > config > semi: false > (oops) => {} > with semi, with newline > it formats ../cases/gjs/simple.gjs 1`] = `
-"<template>what</template>
+"<template>
+  what
+</template>
 ;(oops) => {}
 "
 `;
 
 exports[`ambiguous > config > semi: false > (oops) => {} > with semi, with newline > it formats ../cases/gjs/simple.gjs 2`] = `
-"<template>what</template>
+"<template>
+  what
+</template>
 ;(oops) => {}
 "
 `;
@@ -1127,7 +1143,9 @@ export interface Signature {
   Yields: []
 }
 
-<template>what</template> as TemplateOnlyComponent<Signature>
+<template>
+  what
+</template> as TemplateOnlyComponent<Signature>
 ;(oops) => {}
 "
 `;
@@ -1141,7 +1159,9 @@ export interface Signature {
   Yields: []
 }
 
-<template>what</template> as TemplateOnlyComponent<Signature>
+<template>
+  what
+</template> as TemplateOnlyComponent<Signature>
 ;(oops) => {}
 "
 `;
@@ -1210,7 +1230,9 @@ export interface Signature {
   Yields: []
 }
 
-<template>what</template> as TemplateOnlyComponent<Signature>
+<template>
+  what
+</template> as TemplateOnlyComponent<Signature>
 ;(oops) => {}
 "
 `;
@@ -1275,7 +1297,9 @@ export interface Signature {
   Yields: []
 }
 
-<template>what</template> as TemplateOnlyComponent<Signature>
+<template>
+  what
+</template> as TemplateOnlyComponent<Signature>
 ;(oops) => {}
 "
 `;
@@ -1405,13 +1429,17 @@ const bool = false,
 `;
 
 exports[`ambiguous > config > semi: false > +"oops" > with semi, with newline > it formats ../cases/gjs/simple.gjs 1`] = `
-"<template>what</template>
+"<template>
+  what
+</template>
 ;+\\"oops\\"
 "
 `;
 
 exports[`ambiguous > config > semi: false > +"oops" > with semi, with newline > it formats ../cases/gjs/simple.gjs 2`] = `
-"<template>what</template>
+"<template>
+  what
+</template>
 ;+\\"oops\\"
 "
 `;
@@ -1767,7 +1795,9 @@ export interface Signature {
   Yields: []
 }
 
-<template>what</template> as TemplateOnlyComponent<Signature>
+<template>
+  what
+</template> as TemplateOnlyComponent<Signature>
 ;+\\"oops\\"
 "
 `;
@@ -1781,7 +1811,9 @@ export interface Signature {
   Yields: []
 }
 
-<template>what</template> as TemplateOnlyComponent<Signature>
+<template>
+  what
+</template> as TemplateOnlyComponent<Signature>
 ;+\\"oops\\"
 "
 `;
@@ -1931,13 +1963,17 @@ const bool = false,
 `;
 
 exports[`ambiguous > config > semi: false > /oops/ > with semi, with newline > it formats ../cases/gjs/simple.gjs 1`] = `
-"<template>what</template>
+"<template>
+  what
+</template>
 ;/oops/
 "
 `;
 
 exports[`ambiguous > config > semi: false > /oops/ > with semi, with newline > it formats ../cases/gjs/simple.gjs 2`] = `
-"<template>what</template>
+"<template>
+  what
+</template>
 ;/oops/
 "
 `;
@@ -2293,7 +2329,9 @@ export interface Signature {
   Yields: []
 }
 
-<template>what</template> as TemplateOnlyComponent<Signature>
+<template>
+  what
+</template> as TemplateOnlyComponent<Signature>
 ;/oops/
 "
 `;
@@ -2307,7 +2345,9 @@ export interface Signature {
   Yields: []
 }
 
-<template>what</template> as TemplateOnlyComponent<Signature>
+<template>
+  what
+</template> as TemplateOnlyComponent<Signature>
 ;/oops/
 "
 `;
@@ -2323,7 +2363,9 @@ class MyComponent extends Component {
       template. Class top level template. Class top level template.
     </h1>
   </template>;
-  <template>oops</template>
+  <template>
+    oops
+  </template>
 }
 "
 `;
@@ -2341,7 +2383,9 @@ class MyComponent extends Component {
       template. Class top level template. Class top level template.
     </h1>
   </template>;
-  <template>oops</template>
+  <template>
+    oops
+  </template>
 }
 "
 `;
@@ -2353,7 +2397,9 @@ exports[`ambiguous > config > semi: false > <template>oops</template> > with sem
   component. Explicit default export module top level component. Explicit
   default export module top level component.
 </template>
-<template>oops</template>
+<template>
+  oops
+</template>
 "
 `;
 
@@ -2364,7 +2410,9 @@ exports[`ambiguous > config > semi: false > <template>oops</template> > with sem
   component. Explicit default export module top level component. Explicit
   default export module top level component.
 </template>
-<template>oops</template>
+<template>
+  oops
+</template>
 "
 `;
 
@@ -2374,7 +2422,9 @@ exports[`ambiguous > config > semi: false > <template>oops</template> > with sem
   template. Exported variable template. Exported variable template. Exported
   variable template. Exported variable template.
 </template>
-<template>oops</template>
+<template>
+  oops
+</template>
 "
 `;
 
@@ -2384,19 +2434,25 @@ exports[`ambiguous > config > semi: false > <template>oops</template> > with sem
   template. Exported variable template. Exported variable template. Exported
   variable template. Exported variable template.
 </template>
-<template>oops</template>
+<template>
+  oops
+</template>
 "
 `;
 
 exports[`ambiguous > config > semi: false > <template>oops</template> > with semi, with newline > it formats ../cases/gjs/js-only.gjs 1`] = `
 "const num = 1
-<template>oops</template>
+<template>
+  oops
+</template>
 "
 `;
 
 exports[`ambiguous > config > semi: false > <template>oops</template> > with semi, with newline > it formats ../cases/gjs/js-only.gjs 2`] = `
 "const num = 1
-<template>oops</template>
+<template>
+  oops
+</template>
 "
 `;
 
@@ -2406,7 +2462,9 @@ exports[`ambiguous > config > semi: false > <template>oops</template> > with sem
   template. Private variable template. Private variable template. Private
   variable template. Private variable template.
 </template>
-<template>oops</template>
+<template>
+  oops
+</template>
 "
 `;
 
@@ -2416,7 +2474,9 @@ exports[`ambiguous > config > semi: false > <template>oops</template> > with sem
   template. Private variable template. Private variable template. Private
   variable template. Private variable template.
 </template>
-<template>oops</template>
+<template>
+  oops
+</template>
 "
 `;
 
@@ -2430,7 +2490,9 @@ exports[`ambiguous > config > semi: false > <template>oops</template> > with sem
   </template>,
   ModVar2 = <template>Second module variable template.</template>,
   num = 1
-<template>oops</template>
+<template>
+  oops
+</template>
 
 const bool = false,
   ModVar3 = <template>
@@ -2441,7 +2503,9 @@ const bool = false,
     </h1>
   </template>,
   ModVar4 = <template>Second module variable template.</template>
-<template>oops</template>
+<template>
+  oops
+</template>
 "
 `;
 
@@ -2455,7 +2519,9 @@ exports[`ambiguous > config > semi: false > <template>oops</template> > with sem
   </template>,
   ModVar2 = <template>Second module variable template.</template>,
   num = 1
-<template>oops</template>
+<template>
+  oops
+</template>
 const bool = false,
   ModVar3 = <template>
     <h1>
@@ -2465,19 +2531,29 @@ const bool = false,
     </h1>
   </template>,
   ModVar4 = <template>Second module variable template.</template>
-<template>oops</template>
+<template>
+  oops
+</template>
 "
 `;
 
 exports[`ambiguous > config > semi: false > <template>oops</template> > with semi, with newline > it formats ../cases/gjs/simple.gjs 1`] = `
-"<template>what</template>
-<template>oops</template>
+"<template>
+  what
+</template>
+<template>
+  oops
+</template>
 "
 `;
 
 exports[`ambiguous > config > semi: false > <template>oops</template> > with semi, with newline > it formats ../cases/gjs/simple.gjs 2`] = `
-"<template>what</template>
-<template>oops</template>
+"<template>
+  what
+</template>
+<template>
+  oops
+</template>
 "
 `;
 
@@ -2500,7 +2576,9 @@ class MyComponent extends Component<Signature> {
       template. Class top level template. Class top level template.
     </h1>
   </template>;
-  <template>oops</template>
+  <template>
+    oops
+  </template>
 }
 "
 `;
@@ -2520,7 +2598,9 @@ export interface Signature {
   component. Explicit default export module top level component. Explicit
   default export module top level component.
 </template> as TemplateOnlyComponent<Signature>
-<template>oops</template>
+<template>
+  oops
+</template>
 "
 `;
 
@@ -2539,7 +2619,9 @@ export interface Signature {
   component. Explicit default export module top level component. Explicit
   default export module top level component.
 </template> as TemplateOnlyComponent<Signature>
-<template>oops</template>
+<template>
+  oops
+</template>
 "
 `;
 
@@ -2557,7 +2639,9 @@ export const Exported: TemplateOnlyComponent<Signature> = <template>
   template. Exported variable template. Exported variable template. Exported
   variable template. Exported variable template.
 </template>
-<template>oops</template>
+<template>
+  oops
+</template>
 "
 `;
 
@@ -2575,7 +2659,9 @@ export const Exported: TemplateOnlyComponent<Signature> = <template>
   template. Exported variable template. Exported variable template. Exported
   variable template. Exported variable template.
 </template>
-<template>oops</template>
+<template>
+  oops
+</template>
 "
 `;
 
@@ -2593,7 +2679,9 @@ export const Exported = <template>
   template. Exported variable template. Exported variable template. Exported
   variable template. Exported variable template.
 </template> as TemplateOnlyComponent<Signature>
-<template>oops</template>
+<template>
+  oops
+</template>
 "
 `;
 
@@ -2611,19 +2699,25 @@ export const Exported = <template>
   template. Exported variable template. Exported variable template. Exported
   variable template. Exported variable template.
 </template> as TemplateOnlyComponent<Signature>
-<template>oops</template>
+<template>
+  oops
+</template>
 "
 `;
 
 exports[`ambiguous > config > semi: false > <template>oops</template> > with semi, with newline > it formats ../cases/gts/js-only.gts 1`] = `
 "const num: number = 1
-<template>oops</template>
+<template>
+  oops
+</template>
 "
 `;
 
 exports[`ambiguous > config > semi: false > <template>oops</template> > with semi, with newline > it formats ../cases/gts/js-only.gts 2`] = `
 "const num: number = 1
-<template>oops</template>
+<template>
+  oops
+</template>
 "
 `;
 
@@ -2641,7 +2735,9 @@ const Private: TemplateOnlyComponent<Signature> = <template>
   template. Private variable template. Private variable template. Private
   variable template. Private variable template.
 </template>
-<template>oops</template>
+<template>
+  oops
+</template>
 "
 `;
 
@@ -2659,7 +2755,9 @@ const Private: TemplateOnlyComponent<Signature> = <template>
   template. Private variable template. Private variable template. Private
   variable template. Private variable template.
 </template>
-<template>oops</template>
+<template>
+  oops
+</template>
 "
 `;
 
@@ -2677,7 +2775,9 @@ const Private = <template>
   template. Private variable template. Private variable template. Private
   variable template. Private variable template.
 </template> as TemplateOnlyComponent<Signature>
-<template>oops</template>
+<template>
+  oops
+</template>
 "
 `;
 
@@ -2695,7 +2795,9 @@ const Private = <template>
   template. Private variable template. Private variable template. Private
   variable template. Private variable template.
 </template> as TemplateOnlyComponent<Signature>
-<template>oops</template>
+<template>
+  oops
+</template>
 "
 `;
 
@@ -2719,7 +2821,9 @@ const ModVar1: TemplateOnlyComponent<Signature> = <template>
     Second module variable template.
   </template>,
   num = 1
-<template>oops</template>
+<template>
+  oops
+</template>
 
 const bool: boolean = false,
   ModVar3: TemplateOnlyComponent<Signature> = <template>
@@ -2732,7 +2836,9 @@ const bool: boolean = false,
   ModVar4: TemplateOnlyComponent<Signature> = <template>
     Second module variable template.
   </template>
-<template>oops</template>
+<template>
+  oops
+</template>
 "
 `;
 
@@ -2756,7 +2862,9 @@ const ModVar1: TemplateOnlyComponent<Signature> = <template>
     Second module variable template.
   </template>,
   num = 1
-<template>oops</template>
+<template>
+  oops
+</template>
 const bool: boolean = false,
   ModVar3: TemplateOnlyComponent<Signature> = <template>
     <h1>
@@ -2768,7 +2876,9 @@ const bool: boolean = false,
   ModVar4: TemplateOnlyComponent<Signature> = <template>
     Second module variable template.
   </template>
-<template>oops</template>
+<template>
+  oops
+</template>
 "
 `;
 
@@ -2792,7 +2902,9 @@ const ModVar1 = <template>
     Second module variable template.
   </template> as TemplateOnlyComponent<Signature>,
   num = 1
-<template>oops</template>
+<template>
+  oops
+</template>
 
 const bool: boolean = false,
   ModVar3 = <template>
@@ -2805,7 +2917,9 @@ const bool: boolean = false,
   ModVar4 = <template>
     Second module variable template.
   </template> as TemplateOnlyComponent<Signature>
-<template>oops</template>
+<template>
+  oops
+</template>
 "
 `;
 
@@ -2829,7 +2943,9 @@ const ModVar1 = <template>
     Second module variable template.
   </template> as TemplateOnlyComponent<Signature>,
   num = 1
-<template>oops</template>
+<template>
+  oops
+</template>
 
 const bool: boolean = false,
   ModVar3 = <template>
@@ -2842,7 +2958,9 @@ const bool: boolean = false,
   ModVar4 = <template>
     Second module variable template.
   </template> as TemplateOnlyComponent<Signature>
-<template>oops</template>
+<template>
+  oops
+</template>
 "
 `;
 
@@ -2855,8 +2973,12 @@ export interface Signature {
   Yields: []
 }
 
-<template>what</template> as TemplateOnlyComponent<Signature>
-<template>oops</template>
+<template>
+  what
+</template> as TemplateOnlyComponent<Signature>
+<template>
+  oops
+</template>
 "
 `;
 
@@ -2869,8 +2991,12 @@ export interface Signature {
   Yields: []
 }
 
-<template>what</template> as TemplateOnlyComponent<Signature>
-<template>oops</template>
+<template>
+  what
+</template> as TemplateOnlyComponent<Signature>
+<template>
+  oops
+</template>
 "
 `;
 
@@ -2885,7 +3011,9 @@ class MyComponent extends Component {
       template. Class top level template. Class top level template.
     </h1>
   </template>;
-  <template>oops</template>
+  <template>
+    oops
+  </template>
 }
 "
 `;
@@ -2903,7 +3031,9 @@ class MyComponent extends Component {
       template. Class top level template. Class top level template.
     </h1>
   </template>;
-  <template>oops</template>
+  <template>
+    oops
+  </template>
 }
 "
 `;
@@ -2915,7 +3045,9 @@ exports[`ambiguous > config > semi: false > <template>oops</template> > without 
   component. Explicit default export module top level component. Explicit
   default export module top level component.
 </template>
-<template>oops</template>
+<template>
+  oops
+</template>
 "
 `;
 
@@ -2925,13 +3057,17 @@ exports[`ambiguous > config > semi: false > <template>oops</template> > without 
   template. Exported variable template. Exported variable template. Exported
   variable template. Exported variable template.
 </template>
-<template>oops</template>
+<template>
+  oops
+</template>
 "
 `;
 
 exports[`ambiguous > config > semi: false > <template>oops</template> > without semi, with newline > it formats ../cases/gjs/js-only.gjs 1`] = `
 "const num = 1
-<template>oops</template>
+<template>
+  oops
+</template>
 "
 `;
 
@@ -2941,7 +3077,9 @@ exports[`ambiguous > config > semi: false > <template>oops</template> > without 
   template. Private variable template. Private variable template. Private
   variable template. Private variable template.
 </template>
-<template>oops</template>
+<template>
+  oops
+</template>
 "
 `;
 
@@ -2955,7 +3093,9 @@ exports[`ambiguous > config > semi: false > <template>oops</template> > without 
   </template>,
   ModVar2 = <template>Second module variable template.</template>,
   num = 1
-<template>oops</template>
+<template>
+  oops
+</template>
 
 const bool = false,
   ModVar3 = <template>
@@ -2966,13 +3106,19 @@ const bool = false,
     </h1>
   </template>,
   ModVar4 = <template>Second module variable template.</template>
-<template>oops</template>
+<template>
+  oops
+</template>
 "
 `;
 
 exports[`ambiguous > config > semi: false > <template>oops</template> > without semi, with newline > it formats ../cases/gjs/simple.gjs 1`] = `
-"<template>what</template>
-<template>oops</template>
+"<template>
+  what
+</template>
+<template>
+  oops
+</template>
 "
 `;
 
@@ -2995,7 +3141,9 @@ class MyComponent extends Component<Signature> {
       template. Class top level template. Class top level template.
     </h1>
   </template>;
-  <template>oops</template>
+  <template>
+    oops
+  </template>
 }
 "
 `;
@@ -3015,7 +3163,9 @@ export interface Signature {
   component. Explicit default export module top level component. Explicit
   default export module top level component.
 </template> as TemplateOnlyComponent<Signature>
-<template>oops</template>
+<template>
+  oops
+</template>
 "
 `;
 
@@ -3033,7 +3183,9 @@ export const Exported: TemplateOnlyComponent<Signature> = <template>
   template. Exported variable template. Exported variable template. Exported
   variable template. Exported variable template.
 </template>
-<template>oops</template>
+<template>
+  oops
+</template>
 "
 `;
 
@@ -3051,13 +3203,17 @@ export const Exported = <template>
   template. Exported variable template. Exported variable template. Exported
   variable template. Exported variable template.
 </template> as TemplateOnlyComponent<Signature>
-<template>oops</template>
+<template>
+  oops
+</template>
 "
 `;
 
 exports[`ambiguous > config > semi: false > <template>oops</template> > without semi, with newline > it formats ../cases/gts/js-only.gts 1`] = `
 "const num: number = 1
-<template>oops</template>
+<template>
+  oops
+</template>
 "
 `;
 
@@ -3075,7 +3231,9 @@ const Private: TemplateOnlyComponent<Signature> = <template>
   template. Private variable template. Private variable template. Private
   variable template. Private variable template.
 </template>
-<template>oops</template>
+<template>
+  oops
+</template>
 "
 `;
 
@@ -3093,7 +3251,9 @@ const Private = <template>
   template. Private variable template. Private variable template. Private
   variable template. Private variable template.
 </template> as TemplateOnlyComponent<Signature>
-<template>oops</template>
+<template>
+  oops
+</template>
 "
 `;
 
@@ -3117,7 +3277,9 @@ const ModVar1: TemplateOnlyComponent<Signature> = <template>
     Second module variable template.
   </template>,
   num = 1
-<template>oops</template>
+<template>
+  oops
+</template>
 
 const bool: boolean = false,
   ModVar3: TemplateOnlyComponent<Signature> = <template>
@@ -3130,7 +3292,9 @@ const bool: boolean = false,
   ModVar4: TemplateOnlyComponent<Signature> = <template>
     Second module variable template.
   </template>
-<template>oops</template>
+<template>
+  oops
+</template>
 "
 `;
 
@@ -3154,7 +3318,9 @@ const ModVar1 = <template>
     Second module variable template.
   </template> as TemplateOnlyComponent<Signature>,
   num = 1
-<template>oops</template>
+<template>
+  oops
+</template>
 
 const bool: boolean = false,
   ModVar3 = <template>
@@ -3167,7 +3333,9 @@ const bool: boolean = false,
   ModVar4 = <template>
     Second module variable template.
   </template> as TemplateOnlyComponent<Signature>
-<template>oops</template>
+<template>
+  oops
+</template>
 "
 `;
 
@@ -3180,8 +3348,12 @@ export interface Signature {
   Yields: []
 }
 
-<template>what</template> as TemplateOnlyComponent<Signature>
-<template>oops</template>
+<template>
+  what
+</template> as TemplateOnlyComponent<Signature>
+<template>
+  oops
+</template>
 "
 `;
 
@@ -3195,7 +3367,9 @@ class MyComponent extends Component {
       template. Class top level template. Class top level template.
     </h1>
   </template>;
-  <template>oops</template>
+  <template>
+    oops
+  </template>
 }
 "
 `;
@@ -3212,7 +3386,9 @@ class MyComponent extends Component {
       template. Class top level template. Class top level template.
     </h1>
   </template>;
-  <template>oops</template>
+  <template>
+    oops
+  </template>
 }
 "
 `;
@@ -3224,7 +3400,9 @@ exports[`ambiguous > config > semi: false > <template>oops</template> > without 
   component. Explicit default export module top level component. Explicit
   default export module top level component.
 </template>
-<template>oops</template>
+<template>
+  oops
+</template>
 "
 `;
 
@@ -3234,7 +3412,9 @@ exports[`ambiguous > config > semi: false > <template>oops</template> > without 
   template. Exported variable template. Exported variable template. Exported
   variable template. Exported variable template.
 </template>
-<template>oops</template>
+<template>
+  oops
+</template>
 "
 `;
 
@@ -3244,13 +3424,19 @@ exports[`ambiguous > config > semi: false > <template>oops</template> > without 
   template. Private variable template. Private variable template. Private
   variable template. Private variable template.
 </template>
-<template>oops</template>
+<template>
+  oops
+</template>
 "
 `;
 
 exports[`ambiguous > config > semi: false > <template>oops</template> > without semi, without newline > it formats ../cases/gjs/simple.gjs 1`] = `
-"<template>what</template>
-<template>oops</template>
+"<template>
+  what
+</template>
+<template>
+  oops
+</template>
 "
 `;
 
@@ -3272,7 +3458,9 @@ class MyComponent extends Component<Signature> {
       template. Class top level template. Class top level template.
     </h1>
   </template>;
-  <template>oops</template>
+  <template>
+    oops
+  </template>
 }
 "
 `;
@@ -3291,7 +3479,9 @@ export interface Signature {
   component. Explicit default export module top level component. Explicit
   default export module top level component.
 </template> as TemplateOnlyComponent<Signature>
-<template>oops</template>
+<template>
+  oops
+</template>
 "
 `;
 
@@ -3308,7 +3498,9 @@ export const Exported: TemplateOnlyComponent<Signature> = <template>
   template. Exported variable template. Exported variable template. Exported
   variable template. Exported variable template.
 </template>
-<template>oops</template>
+<template>
+  oops
+</template>
 "
 `;
 
@@ -3325,7 +3517,9 @@ export const Exported = <template>
   template. Exported variable template. Exported variable template. Exported
   variable template. Exported variable template.
 </template> as TemplateOnlyComponent<Signature>
-<template>oops</template>
+<template>
+  oops
+</template>
 "
 `;
 
@@ -3342,7 +3536,9 @@ const Private: TemplateOnlyComponent<Signature> = <template>
   template. Private variable template. Private variable template. Private
   variable template. Private variable template.
 </template>
-<template>oops</template>
+<template>
+  oops
+</template>
 "
 `;
 
@@ -3359,7 +3555,9 @@ const Private = <template>
   template. Private variable template. Private variable template. Private
   variable template. Private variable template.
 </template> as TemplateOnlyComponent<Signature>
-<template>oops</template>
+<template>
+  oops
+</template>
 "
 `;
 
@@ -3371,8 +3569,12 @@ export interface Signature {
   Yields: []
 }
 
-<template>what</template> as TemplateOnlyComponent<Signature>
-<template>oops</template>
+<template>
+  what
+</template> as TemplateOnlyComponent<Signature>
+<template>
+  oops
+</template>
 "
 `;
 
@@ -3569,13 +3771,17 @@ const bool = false,
 `;
 
 exports[`ambiguous > config > semi: false > ["oops"] > with semi, with newline > it formats ../cases/gjs/simple.gjs 1`] = `
-"<template>what</template>
+"<template>
+  what
+</template>
 ;[\\"oops\\"]
 "
 `;
 
 exports[`ambiguous > config > semi: false > ["oops"] > with semi, with newline > it formats ../cases/gjs/simple.gjs 2`] = `
-"<template>what</template>
+"<template>
+  what
+</template>
 ;[\\"oops\\"]
 "
 `;
@@ -3979,7 +4185,9 @@ export interface Signature {
   Yields: []
 }
 
-<template>what</template> as TemplateOnlyComponent<Signature>
+<template>
+  what
+</template> as TemplateOnlyComponent<Signature>
 ;[\\"oops\\"]
 "
 `;
@@ -3993,7 +4201,9 @@ export interface Signature {
   Yields: []
 }
 
-<template>what</template> as TemplateOnlyComponent<Signature>
+<template>
+  what
+</template> as TemplateOnlyComponent<Signature>
 ;[\\"oops\\"]
 "
 `;
@@ -4166,7 +4376,9 @@ export interface Signature {
   Yields: []
 }
 
-<template>what</template> as TemplateOnlyComponent<Signature>
+<template>
+  what
+</template> as TemplateOnlyComponent<Signature>
 ;[\\"oops\\"]
 "
 `;
@@ -4331,7 +4543,9 @@ export interface Signature {
   Yields: []
 }
 
-<template>what</template> as TemplateOnlyComponent<Signature>
+<template>
+  what
+</template> as TemplateOnlyComponent<Signature>
 ;[\\"oops\\"]
 "
 `;
@@ -4461,13 +4675,17 @@ const bool = false,
 `;
 
 exports[`ambiguous > config > semi: false > \`oops\` > with semi, with newline > it formats ../cases/gjs/simple.gjs 1`] = `
-"<template>what</template>
+"<template>
+  what
+</template>
 ;\`oops\`
 "
 `;
 
 exports[`ambiguous > config > semi: false > \`oops\` > with semi, with newline > it formats ../cases/gjs/simple.gjs 2`] = `
-"<template>what</template>
+"<template>
+  what
+</template>
 ;\`oops\`
 "
 `;
@@ -4823,7 +5041,9 @@ export interface Signature {
   Yields: []
 }
 
-<template>what</template> as TemplateOnlyComponent<Signature>
+<template>
+  what
+</template> as TemplateOnlyComponent<Signature>
 ;\`oops\`
 "
 `;
@@ -4837,7 +5057,9 @@ export interface Signature {
   Yields: []
 }
 
-<template>what</template> as TemplateOnlyComponent<Signature>
+<template>
+  what
+</template> as TemplateOnlyComponent<Signature>
 ;\`oops\`
 "
 `;
@@ -4952,7 +5174,9 @@ export interface Signature {
   Yields: []
 }
 
-<template>what</template> as TemplateOnlyComponent<Signature>
+<template>
+  what
+</template> as TemplateOnlyComponent<Signature>
 ;\`oops\`
 "
 `;
@@ -5062,7 +5286,9 @@ export interface Signature {
   Yields: []
 }
 
-<template>what</template> as TemplateOnlyComponent<Signature>
+<template>
+  what
+</template> as TemplateOnlyComponent<Signature>
 ;\`oops\`
 "
 `;
@@ -5192,13 +5418,17 @@ const bool = false,
 `;
 
 exports[`ambiguous > config > semi: false > -"oops" > with semi, with newline > it formats ../cases/gjs/simple.gjs 1`] = `
-"<template>what</template>
+"<template>
+  what
+</template>
 ;-\\"oops\\"
 "
 `;
 
 exports[`ambiguous > config > semi: false > -"oops" > with semi, with newline > it formats ../cases/gjs/simple.gjs 2`] = `
-"<template>what</template>
+"<template>
+  what
+</template>
 ;-\\"oops\\"
 "
 `;
@@ -5554,7 +5784,9 @@ export interface Signature {
   Yields: []
 }
 
-<template>what</template> as TemplateOnlyComponent<Signature>
+<template>
+  what
+</template> as TemplateOnlyComponent<Signature>
 ;-\\"oops\\"
 "
 `;
@@ -5568,7 +5800,9 @@ export interface Signature {
   Yields: []
 }
 
-<template>what</template> as TemplateOnlyComponent<Signature>
+<template>
+  what
+</template> as TemplateOnlyComponent<Signature>
 ;-\\"oops\\"
 "
 `;

--- a/tests/unit-tests/config/__snapshots__/semi-false.test.ts.snap
+++ b/tests/unit-tests/config/__snapshots__/semi-false.test.ts.snap
@@ -246,7 +246,9 @@ exports[`config > semi: false > it formats ../cases/gjs/prettier-ignore/simple.g
 `;
 
 exports[`config > semi: false > it formats ../cases/gjs/simple.gjs 1`] = `
-"<template>what</template>
+"<template>
+  what
+</template>
 "
 `;
 
@@ -724,6 +726,8 @@ export interface Signature {
   Yields: []
 }
 
-<template>what</template> as TemplateOnlyComponent<Signature>
+<template>
+  what
+</template> as TemplateOnlyComponent<Signature>
 "
 `;

--- a/tests/unit-tests/config/__snapshots__/template-export-default.test.ts.snap
+++ b/tests/unit-tests/config/__snapshots__/template-export-default.test.ts.snap
@@ -246,7 +246,9 @@ exports[`config > templateExportDefault: true > it formats ../cases/gjs/prettier
 `;
 
 exports[`config > templateExportDefault: true > it formats ../cases/gjs/simple.gjs 1`] = `
-"export default <template>what</template>
+"export default <template>
+  what
+</template>
 "
 `;
 
@@ -724,6 +726,8 @@ export interface Signature {
   Yields: [];
 }
 
-export default <template>what</template> as TemplateOnlyComponent<Signature>
+export default <template>
+  what
+</template> as TemplateOnlyComponent<Signature>
 "
 `;


### PR DESCRIPTION
Default exports and top-level class templates should always print template tags on newlines, even if they _could_ fit on the same line.

```
import Component from '@glimmer/component';

const what = <template>as const</template>;

export const who = <template>exported const</template>;

<template>
  default export
</template>

class MyComponent extends Component {
  <template>
    Class Level
  </template>
}
```

A similar convention is used by Prettier for printing functions.

e.g. `const add = (a, b) => a + b;` is allowed to print on one line but the following would always print with the braces on theri own line:

```
function add(a, b) {
  return a + b;
}
```