### PR TITLE
No-op for invalid hbs (Fixes #43)

### DIFF
--- a/src/print/index.ts
+++ b/src/print/index.ts
@@ -128,28 +128,35 @@ export function definePrinter(options: Options): void {
 
     if (hasPrettierIgnore) {
       return printRawText(path, embedOptions);
-    } else if (wasPreprocessed && isGlimmerTemplateLiteral(node)) {
-      return printTemplateLiteral(
-        printTemplateContent(node, textToDoc, embedOptions)
-      );
-    } else if (!wasPreprocessed && isGlimmerClassProperty(node)) {
-      return printTemplateTag(
-        printTemplateContent(node.key.arguments[0], textToDoc, embedOptions),
-        node.extra.isDefaultTemplate ?? false
-      );
-    } else if (!wasPreprocessed && isGlimmerArrayExpression(node)) {
-      return printTemplateTag(
-        printTemplateContent(
-          node.elements[0].arguments[0],
-          textToDoc,
-          embedOptions
-        ),
-        node.extra.isDefaultTemplate ?? false
-      );
-    } else {
-      // Nothing to embed, so move on to the regular printer.
-      return null;
     }
+
+    try {
+      if (wasPreprocessed && isGlimmerTemplateLiteral(node)) {
+        return printTemplateLiteral(
+          printTemplateContent(node, textToDoc, embedOptions)
+        );
+      } else if (!wasPreprocessed && isGlimmerClassProperty(node)) {
+        return printTemplateTag(
+          printTemplateContent(node.key.arguments[0], textToDoc, embedOptions),
+          node.extra.isDefaultTemplate ?? false
+        );
+      } else if (!wasPreprocessed && isGlimmerArrayExpression(node)) {
+        return printTemplateTag(
+          printTemplateContent(
+            node.elements[0].arguments[0],
+            textToDoc,
+            embedOptions
+          ),
+          node.extra.isDefaultTemplate ?? false
+        );
+      }
+    } catch (error: unknown) {
+      console.error(error);
+      return printRawText(path, embedOptions);
+    }
+
+    // Nothing to embed, so move on to the regular printer.
+    return null;
   };
 
   /**

--- a/tests/cases/gjs/invalid-template.gjs
+++ b/tests/cases/gjs/invalid-template.gjs
@@ -1,0 +1,3 @@
+<template>
+              {{#if oops}}
+            </template>

--- a/tests/unit-tests/__snapshots__/format.test.ts.snap
+++ b/tests/unit-tests/__snapshots__/format.test.ts.snap
@@ -117,6 +117,13 @@ exports[`format > config > default > it formats ../cases/gjs/exported-mod-var.gj
 "
 `;
 
+exports[`format > config > default > it formats ../cases/gjs/invalid-template.gjs 1`] = `
+"<template>
+              {{#if oops}}
+            </template>
+"
+`;
+
 exports[`format > config > default > it formats ../cases/gjs/js-only.gjs 1`] = `
 "const num = 1;
 "

--- a/tests/unit-tests/__snapshots__/preprocessed.test.ts.snap
+++ b/tests/unit-tests/__snapshots__/preprocessed.test.ts.snap
@@ -127,6 +127,17 @@ exports[`format > config > with preprocessed code > it formats ../cases/gjs/expo
 "
 `;
 
+exports[`format > config > with preprocessed code > it formats ../cases/gjs/invalid-template.gjs 1`] = `
+"[
+  __GLIMMER_TEMPLATE(\`
+              {{#if oops}}
+            \`, {
+    strictMode: true,
+  }),
+]
+"
+`;
+
 exports[`format > config > with preprocessed code > it formats ../cases/gjs/js-only.gjs 1`] = `
 "const num = 1;
 "

--- a/tests/unit-tests/config/__snapshots__/semi-false.test.ts.snap
+++ b/tests/unit-tests/config/__snapshots__/semi-false.test.ts.snap
@@ -117,6 +117,13 @@ exports[`config > semi: false > it formats ../cases/gjs/exported-mod-var.gjs 1`]
 "
 `;
 
+exports[`config > semi: false > it formats ../cases/gjs/invalid-template.gjs 1`] = `
+"<template>
+              {{#if oops}}
+            </template>
+"
+`;
+
 exports[`config > semi: false > it formats ../cases/gjs/js-only.gjs 1`] = `
 "const num = 1
 "

--- a/tests/unit-tests/config/__snapshots__/template-export-default.test.ts.snap
+++ b/tests/unit-tests/config/__snapshots__/template-export-default.test.ts.snap
@@ -117,6 +117,13 @@ exports[`config > templateExportDefault: true > it formats ../cases/gjs/exported
 "
 `;
 
+exports[`config > templateExportDefault: true > it formats ../cases/gjs/invalid-template.gjs 1`] = `
+"export default <template>
+              {{#if oops}}
+            </template>
+"
+`;
+
 exports[`config > templateExportDefault: true > it formats ../cases/gjs/js-only.gjs 1`] = `
 "const num = 1;
 "


### PR DESCRIPTION
This is similar to prettier's typical behavior for JS syntax errors