### PR TITLE
Upgrade to Prettier 3 (Fixes #61); Breaks compatibility with Prettier 2

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -2,4 +2,7 @@ module.exports = {
   plugins: ['prettier-plugin-jsdoc'],
   singleQuote: true,
   tsdoc: true,
+
+  // TODO: Remove this in the next PR
+  trailingComma: 'es5',
 };

--- a/@types/prettier/plugins/estree.d.ts
+++ b/@types/prettier/plugins/estree.d.ts
@@ -1,0 +1,10 @@
+import type { Printer, SupportLanguage, SupportOptions } from 'prettier';
+
+declare const printers: {
+  estree: Printer;
+  'estree-json': Printer;
+};
+
+declare const languages: SupportLanguage[];
+
+declare const options: SupportOptions;

--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@
 
 A [Prettier](https://prettier.io/) plugin for formatting [Ember template tags](https://rfcs.emberjs.com/id/0779-first-class-component-templates/) in both `.gjs` and `.gts` files. See also [Ember Template Imports](https://github.com/ember-template-imports/ember-template-imports).
 
+## Compatibility
+
+Prettier 3.0.0 and above
+
 ## Usage
 
 1. Install:

--- a/examples/package.json
+++ b/examples/package.json
@@ -7,7 +7,7 @@
     "example-ts": "pnpm exec prettier --write ./example.gts"
   },
   "dependencies": {
-    "prettier": "^2.8.8",
+    "prettier": "^3.0.0",
     "prettier-plugin-ember-template-tag": "workspace:^"
   }
 }

--- a/index.html
+++ b/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@glimmer/syntax": "^0.84.3",
     "ember-cli-htmlbars": "^6.2.0",
     "ember-template-imports": "^3.4.2",
-    "prettier": "^2.8.8"
+    "prettier": "^3.0.0"
   },
   "devDependencies": {
     "@babel/types": "^7.22.5",
@@ -64,7 +64,6 @@
     "@types/babel__core": "^7.20.1",
     "@types/eslint": "^8.44.0",
     "@types/node": "^20.4.4",
-    "@types/prettier": "^2.7.3",
     "@typescript-eslint/eslint-plugin": "^6.1.0",
     "@typescript-eslint/parser": "^6.1.0",
     "@vitest/ui": "^0.33.0",
@@ -76,7 +75,7 @@
     "eslint-plugin-n": "^16.0.1",
     "eslint-plugin-unicorn": "^48.0.0",
     "eslint-plugin-vitest": "^0.2.6",
-    "prettier-plugin-jsdoc": "^0.4.2",
+    "prettier-plugin-jsdoc": "^1.0.1",
     "release-it": "^16.1.3",
     "typescript": "^5.1.6",
     "vite": "^4.4.6",

--- a/package.json
+++ b/package.json
@@ -81,6 +81,9 @@
     "vite": "^4.4.6",
     "vitest": "^0.33.0"
   },
+  "peerDependencies": {
+    "prettier": ">3.0.0"
+  },
   "engines": {
     "node": "16.* || 18.* || >= 20"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,8 +21,8 @@ importers:
         specifier: ^3.4.2
         version: 3.4.2
       prettier:
-        specifier: ^2.8.8
-        version: 2.8.8
+        specifier: ^3.0.0
+        version: 3.0.0
     devDependencies:
       '@babel/types':
         specifier: ^7.22.5
@@ -45,9 +45,6 @@ importers:
       '@types/node':
         specifier: ^20.4.4
         version: 20.4.4
-      '@types/prettier':
-        specifier: ^2.7.3
-        version: 2.7.3
       '@typescript-eslint/eslint-plugin':
         specifier: ^6.1.0
         version: 6.1.0(@typescript-eslint/parser@6.1.0)(eslint@8.45.0)(typescript@5.1.6)
@@ -82,8 +79,8 @@ importers:
         specifier: ^0.2.6
         version: 0.2.6(eslint@8.45.0)(typescript@5.1.6)
       prettier-plugin-jsdoc:
-        specifier: ^0.4.2
-        version: 0.4.2(prettier@2.8.8)
+        specifier: ^1.0.1
+        version: 1.0.1(prettier@3.0.0)
       release-it:
         specifier: ^16.1.3
         version: 16.1.3
@@ -100,8 +97,8 @@ importers:
   examples:
     dependencies:
       prettier:
-        specifier: ^2.8.8
-        version: 2.8.8
+        specifier: ^3.0.0
+        version: 3.0.0
       prettier-plugin-ember-template-tag:
         specifier: workspace:^
         version: link:..
@@ -998,10 +995,6 @@ packages:
 
   /@types/normalize-package-data@2.4.1:
     resolution: {integrity: sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==}
-    dev: true
-
-  /@types/prettier@2.7.3:
-    resolution: {integrity: sha512-+68kP9yzs4LMp7VNh8gdzMSPZFL44MLGqiHWvttYJe+6qnuVr4Ek9wSBQoveqY/r+LwjCcU29kNVkidwim+kYA==}
     dev: true
 
   /@types/semver@7.5.0:
@@ -4840,23 +4833,23 @@ packages:
     engines: {node: '>= 0.8.0'}
     dev: true
 
-  /prettier-plugin-jsdoc@0.4.2(prettier@2.8.8):
-    resolution: {integrity: sha512-w2jnAQm3z0GAG0bhzVJeehzDtrhGMSxJjit5ApCc2oxWfc7+jmLAkbtdOXaSpfwZz3IWkk+PiQPeRrLNpbM+Mw==}
-    engines: {node: '>=12.0.0'}
+  /prettier-plugin-jsdoc@1.0.1(prettier@3.0.0):
+    resolution: {integrity: sha512-07q74MfX9m+xHK2+Lr4c+igiEzAKVDWhqkvlm65WoYJUlRiaV6STXcEtcZMhrPPYgNeQRgb9FJmgE/n+OI4MpQ==}
+    engines: {node: '>=14.13.1 || >=16.0.0'}
     peerDependencies:
-      prettier: '>=2.1.2'
+      prettier: ^3.0.0
     dependencies:
       binary-searching: 2.0.5
       comment-parser: 1.3.1
       mdast-util-from-markdown: 1.3.0
-      prettier: 2.8.8
+      prettier: 3.0.0
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /prettier@2.8.8:
-    resolution: {integrity: sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==}
-    engines: {node: '>=10.13.0'}
+  /prettier@3.0.0:
+    resolution: {integrity: sha512-zBf5eHpwHOGPC47h0zrPyNn+eAEIdEzfywMoYn2XPi0P44Zp0tSq64rq0xAREh4auw2cJZHo9QUob+NqCQky4g==}
+    engines: {node: '>=14'}
     hasBin: true
 
   /pretty-format@29.6.1:

--- a/src/options.ts
+++ b/src/options.ts
@@ -12,11 +12,11 @@ export interface Options extends ParserOptions<Node | undefined> {
 }
 
 const templateExportDefault: BooleanSupportOption = {
-  since: '0.1.0',
   category: 'Format',
   type: 'boolean',
   default: false,
-  description: 'Prepend default export template tags with "export default".',
+  description:
+    'Prepend default export template tags with "export default". Since 0.1.0.',
 };
 
 /**
@@ -32,19 +32,17 @@ export function getTemplateSingleQuote(options: Options): boolean {
 }
 
 const templateSingleQuote: BooleanSupportOption = {
-  since: '0.0.3',
   category: 'Format',
   type: 'boolean',
   description:
-    'Use single quotes instead of double quotes within template tags.',
+    'Use single quotes instead of double quotes within template tags. Since 0.0.3.',
 };
 
 const __inputWasPreprocessed: BooleanSupportOption = {
-  since: '0.1.0',
   category: 'Format',
   type: 'boolean',
   description:
-    'Internal: If true, the template was preprocessed before being run through Prettier.',
+    'Internal: If true, the template was preprocessed before being run through Prettier. Since 0.1.0.',
 };
 
 export const options: SupportOptions = {

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -80,12 +80,11 @@ export const parser: Parser<Node | undefined> = {
     return typescript.preprocess?.(js, options) ?? js;
   },
 
-  parse(
+  async parse(
     text: string,
-    parsers: Record<string, Parser<unknown>>,
     options: Options
-  ): Node {
-    const ast = typescript.parse(text, parsers, options);
+  ): Promise<Node> {
+    const ast = await typescript.parse(text, options);
     assert('expected ast', ast);
     traverse(ast, {
       enter: makeEnter(options),

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -80,10 +80,7 @@ export const parser: Parser<Node | undefined> = {
     return typescript.preprocess?.(js, options) ?? js;
   },
 
-  async parse(
-    text: string,
-    options: Options
-  ): Promise<Node> {
+  async parse(text: string, options: Options): Promise<Node> {
     const ast = await typescript.parse(text, options);
     assert('expected ast', ast);
     traverse(ast, {

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -9,7 +9,7 @@ import {
 import { getTemplateLocals } from '@glimmer/syntax';
 import { preprocessEmbeddedTemplates } from 'ember-template-imports/lib/preprocess-embedded-templates';
 import type { Parser } from 'prettier';
-import { parsers as babelParsers } from 'prettier/parser-babel';
+import { parsers as babelParsers } from 'prettier/plugins/babel';
 import {
   PRINTER_NAME,
   TEMPLATE_TAG_NAME,

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -16,7 +16,6 @@ import {
   TEMPLATE_TAG_PLACEHOLDER,
 } from './config';
 import type { Options } from './options';
-import { definePrinter } from './print/index';
 import type {
   GlimmerExpressionExtra,
   GlimmerTemplateExtra,
@@ -75,7 +74,6 @@ export const parser: Parser<Node | undefined> = {
   astFormat: PRINTER_NAME,
 
   preprocess(text: string, options: Options): string {
-    definePrinter(options);
     const js = preprocess(text, options);
     return typescript.preprocess?.(js, options) ?? js;
   },

--- a/src/print/index.ts
+++ b/src/print/index.ts
@@ -129,7 +129,7 @@ export const printer: Printer<Node | undefined> = {
       }
 
       // Nothing to embed, so move on to the regular printer.
-      return undefined;
+      return;
     };
   },
 
@@ -145,7 +145,7 @@ export const printer: Printer<Node | undefined> = {
  * Remove the semicolons and empty strings that Prettier added so we can manage
  * them.
  */
-function trimPrinted(printed: doc.builders.Doc[]) {
+function trimPrinted(printed: doc.builders.Doc[]): void {
   while (
     docMatchesString(printed[0], ';') ||
     docMatchesString(printed[0], '')

--- a/src/print/index.ts
+++ b/src/print/index.ts
@@ -93,18 +93,16 @@ export const printer: Printer<Node | undefined> = {
       return printRawText(path, embedOptions as Options);
     }
 
-    try {
-      if (wasPreprocessed && isGlimmerTemplateLiteral(node)) {
-        return async (textToDoc) => {
+    return async (textToDoc) => {
+      try {
+        if (wasPreprocessed && isGlimmerTemplateLiteral(node)) {
           const content = await printTemplateContent(
             node,
             textToDoc,
             embedOptions as Options
           );
           return printTemplateLiteral(content);
-        };
-      } else if (!wasPreprocessed && isGlimmerClassProperty(node)) {
-        return async (textToDoc) => {
+        } else if (!wasPreprocessed && isGlimmerClassProperty(node)) {
           const content = await printTemplateContent(
             node.key.arguments[0],
             textToDoc,
@@ -114,9 +112,7 @@ export const printer: Printer<Node | undefined> = {
             content,
             node.extra.isDefaultTemplate ?? false
           );
-        };
-      } else if (!wasPreprocessed && isGlimmerArrayExpression(node)) {
-        return async (textToDoc) => {
+        } else if (!wasPreprocessed && isGlimmerArrayExpression(node)) {
           const content = await printTemplateContent(
             node.elements[0].arguments[0],
             textToDoc,
@@ -126,15 +122,15 @@ export const printer: Printer<Node | undefined> = {
             content,
             node.extra.isDefaultTemplate ?? false
           );
-        };
+        }
+      } catch (error: unknown) {
+        console.error(error);
+        return printRawText(path, embedOptions as Options);
       }
-    } catch (error: unknown) {
-      console.error(error);
-      return printRawText(path, embedOptions as Options);
-    }
 
-    // Nothing to embed, so move on to the regular printer.
-    return null;
+      // Nothing to embed, so move on to the regular printer.
+      return undefined;
+    };
   },
 
   /**

--- a/src/print/index.ts
+++ b/src/print/index.ts
@@ -1,5 +1,11 @@
 import type { Node } from '@babel/types';
-import type { AstPath, doc, Plugin, Printer } from 'prettier';
+import type {
+  AstPath,
+  Plugin,
+  Options as PrettierOptions,
+  Printer,
+  doc,
+} from 'prettier';
 import {
   TEMPLATE_TAG_CLOSE,
   TEMPLATE_TAG_OPEN,
@@ -114,7 +120,7 @@ export function definePrinter(options: Options): void {
   /** Prints embedded GlimmerExpressions/GlimmerTemplates. */
   printer.embed = (
     path: AstPath<Node | undefined>,
-    embedOptions: any // FIXME
+    embedOptions: PrettierOptions
   ) => {
     const wasPreprocessed = options.__inputWasPreprocessed;
     const node = path.getValue();
@@ -124,7 +130,7 @@ export function definePrinter(options: Options): void {
     );
 
     if (hasPrettierIgnore) {
-      return printRawText(path, embedOptions);
+      return printRawText(path, embedOptions as Options);
     }
 
     try {
@@ -133,7 +139,7 @@ export function definePrinter(options: Options): void {
           const content = await printTemplateContent(
             node,
             textToDoc,
-            embedOptions
+            embedOptions as Options
           );
           return printTemplateLiteral(content);
         };
@@ -142,7 +148,7 @@ export function definePrinter(options: Options): void {
           const content = await printTemplateContent(
             node.key.arguments[0],
             textToDoc,
-            embedOptions
+            embedOptions as Options
           );
           return printTemplateTag(
             content,
@@ -154,7 +160,7 @@ export function definePrinter(options: Options): void {
           const content = await printTemplateContent(
             node.elements[0].arguments[0],
             textToDoc,
-            embedOptions
+            embedOptions as Options
           );
           return printTemplateTag(
             content,
@@ -164,7 +170,7 @@ export function definePrinter(options: Options): void {
       }
     } catch (error: unknown) {
       console.error(error);
-      return printRawText(path, embedOptions);
+      return printRawText(path, embedOptions as Options);
     }
 
     // Nothing to embed, so move on to the regular printer.

--- a/src/print/index.ts
+++ b/src/print/index.ts
@@ -54,17 +54,8 @@ export const printer: Printer<Node | undefined> = {
         return printRawText(path, options);
       } else {
         let printed = estreePrinter.print(path, options, print, args);
-
         assert('Expected Glimmer doc to be an array', Array.isArray(printed));
-
-        // Remove the semicolons that Prettier added so we can manage them
-        if (docMatchesString(printed[0], ';')) {
-          printed.shift();
-        }
-
-        if (docMatchesString(printed.at(-1), ';')) {
-          printed.pop();
-        }
+        trimPrinted(printed);
 
         if (
           !options.templateExportDefault &&
@@ -72,9 +63,7 @@ export const printer: Printer<Node | undefined> = {
           docMatchesString(printed[1], 'default')
         ) {
           printed = printed.slice(2);
-          if (docMatchesString(printed[0], '')) {
-            printed.shift();
-          }
+          trimPrinted(printed);
         }
 
         if (options.semi && getGlimmerExpression(node).extra.forceSemi) {
@@ -155,6 +144,26 @@ export const printer: Printer<Node | undefined> = {
    */
   hasPrettierIgnore: undefined,
 };
+
+/**
+ * Remove the semicolons and empty strings that Prettier added so we can manage
+ * them.
+ */
+function trimPrinted(printed: doc.builders.Doc[]) {
+  while (
+    docMatchesString(printed[0], ';') ||
+    docMatchesString(printed[0], '')
+  ) {
+    printed.shift();
+  }
+
+  while (
+    docMatchesString(printed.at(-1), ';') ||
+    docMatchesString(printed.at(-1), '')
+  ) {
+    printed.pop();
+  }
+}
 
 function printRawText(
   { node }: AstPath<Node | undefined>,

--- a/src/print/template.ts
+++ b/src/print/template.ts
@@ -1,5 +1,5 @@
-import type { Node, TemplateLiteral } from '@babel/types';
-import type { ParserOptions } from 'prettier';
+import type { TemplateLiteral } from '@babel/types';
+import type { Options as PrettierOptions } from 'prettier';
 import { doc } from 'prettier';
 import { TEMPLATE_TAG_CLOSE, TEMPLATE_TAG_OPEN } from '../config';
 import type { Options } from '../options';
@@ -22,7 +22,7 @@ export async function printTemplateContent(
     // Don't use our `Options` here even though technically they are available
     // because we don't want to accidentally pass them into `textToDoc`. We
     // should normalize them into standard Prettier options at this point.
-    options: ParserOptions<Node | undefined>
+    options: PrettierOptions
   ) => Promise<doc.builders.Doc>,
   options: Options
 ): Promise<doc.builders.Doc> {

--- a/src/print/template.ts
+++ b/src/print/template.ts
@@ -15,7 +15,7 @@ const {
  *
  * NOTE: The contents are not surrounded with "`"
  */
-export function printTemplateContent(
+export async function printTemplateContent(
   node: TemplateLiteral,
   textToDoc: (
     text: string,
@@ -23,11 +23,11 @@ export function printTemplateContent(
     // because we don't want to accidentally pass them into `textToDoc`. We
     // should normalize them into standard Prettier options at this point.
     options: ParserOptions<Node | undefined>
-  ) => doc.builders.Doc,
+  ) => Promise<doc.builders.Doc>,
   options: Options
-): doc.builders.Doc {
+): Promise<doc.builders.Doc> {
   const text = node.quasis.map((quasi) => quasi.value.raw).join(' ');
-  return textToDoc(text.trim(), {
+  return await textToDoc(text.trim(), {
     ...options,
     parser: 'glimmer',
     singleQuote: getTemplateSingleQuote(options),

--- a/tests/helpers/ambiguous.ts
+++ b/tests/helpers/ambiguous.ts
@@ -71,7 +71,7 @@ export function makeAmbiguousExpressionTest(
             await behavesLikeFormattedAmbiguousCase(code, config.options);
           });
         });
-        describe('with semi, with newline', () => {
+        describe('with semi, without newline', () => {
           test(`it formats ${testCase.name}`, async () => {
             const code = testCase.code
               .replaceAll(AMBIGUOUS_PLACEHOLDER, ambiguousExpression)

--- a/tests/helpers/ambiguous.ts
+++ b/tests/helpers/ambiguous.ts
@@ -47,37 +47,37 @@ export function makeAmbiguousExpressionTest(
     for (const ambiguousExpression of ambiguousExpressions) {
       describe(ambiguousExpression, () => {
         describe('without semi, with newline', () => {
-          test(`it formats ${testCase.name}`, () => {
+          test(`it formats ${testCase.name}`, async () => {
             const code = testCase.code
               .replaceAll(AMBIGUOUS_PLACEHOLDER, ambiguousExpression)
               .replaceAll(';\n', '\n');
-            behavesLikeFormattedAmbiguousCase(code, config.options);
+            await behavesLikeFormattedAmbiguousCase(code, config.options);
           });
         });
         describe('with semi, with newline', () => {
-          test(`it formats ${testCase.name}`, () => {
+          test(`it formats ${testCase.name}`, async () => {
             const code = testCase.code
               .replaceAll(AMBIGUOUS_PLACEHOLDER, ambiguousExpression)
               .replaceAll('</template>\n', '</template>;\n')
               .replaceAll('<Signature>\n', '<Signature>;\n');
-            behavesLikeFormattedAmbiguousCase(code, config.options);
+            await behavesLikeFormattedAmbiguousCase(code, config.options);
           });
         });
         describe('without semi, without newline', () => {
-          test(`it formats ${testCase.name}`, () => {
+          test(`it formats ${testCase.name}`, async () => {
             const code = testCase.code
               .replaceAll(AMBIGUOUS_PLACEHOLDER, ambiguousExpression)
               .replaceAll(';\n', '');
-            behavesLikeFormattedAmbiguousCase(code, config.options);
+            await behavesLikeFormattedAmbiguousCase(code, config.options);
           });
         });
         describe('with semi, with newline', () => {
-          test(`it formats ${testCase.name}`, () => {
+          test(`it formats ${testCase.name}`, async () => {
             const code = testCase.code
               .replaceAll(AMBIGUOUS_PLACEHOLDER, ambiguousExpression)
               .replaceAll('</template>\n', '</template>;')
               .replaceAll('<Signature>\n', '<Signature>;');
-            behavesLikeFormattedAmbiguousCase(code, config.options);
+            await behavesLikeFormattedAmbiguousCase(code, config.options);
           });
         });
       });
@@ -85,12 +85,12 @@ export function makeAmbiguousExpressionTest(
   };
 }
 
-function behavesLikeFormattedAmbiguousCase(
+async function behavesLikeFormattedAmbiguousCase(
   code: string,
   formatOptions: Partial<Options> = {}
-): void {
+): Promise<void> {
   try {
-    const result = format(code, formatOptions);
+    const result = await format(code, formatOptions);
     expect(result).toMatchSnapshot();
   } catch (error: unknown) {
     // Some of the ambiguous cases are Syntax Errors when parsed

--- a/tests/helpers/format.ts
+++ b/tests/helpers/format.ts
@@ -14,8 +14,11 @@ const DEFAULT_OPTIONS: Partial<Options> = {
  * Optionally, provide Options overrides, which will be merged with the default
  * options.
  */
-export function format(code: string, overrides: Partial<Options> = {}): string {
-  return prettierFormat(code, {
+export async function format(
+  code: string,
+  overrides: Partial<Options> = {}
+): Promise<string> {
+  return await prettierFormat(code, {
     ...DEFAULT_OPTIONS,
     ...overrides,
   });

--- a/tests/helpers/make-suite.ts
+++ b/tests/helpers/make-suite.ts
@@ -52,9 +52,9 @@ export const describeAmbiguitySuite = makeSuite(
 
 /** Runs a simple `format` test for the given `config` and `testCase` */
 export function simpleTest(config: Config, testCase: TestCase): void {
-  test(`it formats ${testCase.name}`, () => {
+  test(`it formats ${testCase.name}`, async () => {
     const code = testCase.code.replaceAll(AMBIGUOUS_PLACEHOLDER, '');
-    const result = format(code, config.options);
+    const result = await format(code, config.options);
     expect(result).toMatchSnapshot();
   });
 }

--- a/tests/unit-tests/__snapshots__/preprocessed.test.ts.snap
+++ b/tests/unit-tests/__snapshots__/preprocessed.test.ts.snap
@@ -21,7 +21,7 @@ export default class ProjectStatusComponent extends Component {
       <Icon @type={{this.iconType}} @id={{this.iconId}} />
       {{@project.status}}{{if this.restartProject.isRunning \\"...\\"}}
     </Button>\`,
-    { strictMode: true }
+    { strictMode: true },
   )]
 
   @service server;
@@ -60,7 +60,7 @@ class MyComponent extends Component {
       Class top level template. Class top level template. Class top level
       template. Class top level template. Class top level template.
     </h1>\`,
-    { strictMode: true }
+    { strictMode: true },
   )]
 }
 "
@@ -78,7 +78,7 @@ class MyComponent extends Component {
       Class top level template. Class top level template. Class top level
       template. Class top level template. Class top level template.
     </h1>\`,
-    { strictMode: true }
+    { strictMode: true },
   )]
 }
 "
@@ -94,7 +94,7 @@ class MyComponent extends Component {
       Class top level template. Class top level template. Class top level
       template. Class top level template. Class top level template.
     </h1>\`,
-    { strictMode: true }
+    { strictMode: true },
   )]
 
   what = \`template literal that is not a template\`;
@@ -109,7 +109,7 @@ exports[`format > config > with preprocessed code > it formats ../cases/gjs/defa
     module top level component. Explicit default export module top level
     component. Explicit default export module top level component. Explicit
     default export module top level component.\`,
-    { strictMode: true }
+    { strictMode: true },
   ),
 ]
 "
@@ -121,7 +121,7 @@ exports[`format > config > with preprocessed code > it formats ../cases/gjs/expo
     \`Exported variable template. Exported variable template. Exported variable
     template. Exported variable template. Exported variable template. Exported
     variable template. Exported variable template.\`,
-    { strictMode: true }
+    { strictMode: true },
   ),
 ];
 "
@@ -149,7 +149,7 @@ exports[`format > config > with preprocessed code > it formats ../cases/gjs/mod-
     \`Private variable template. Private variable template. Private variable
     template. Private variable template. Private variable template. Private
     variable template. Private variable template.\`,
-    { strictMode: true }
+    { strictMode: true },
   ),
 ];
 
@@ -165,7 +165,7 @@ exports[`format > config > with preprocessed code > it formats ../cases/gjs/mult
         template. Module variable template. Module variable template. Module
         variable template. Module variable template. Module variable template.
       </h1>\`,
-      { strictMode: true }
+      { strictMode: true },
     ),
   ],
   ModVar2 = [
@@ -183,7 +183,7 @@ const bool = false,
         template. Module variable template. Module variable template. Module
         variable template. Module variable template. Module variable template.
       </h1>\`,
-      { strictMode: true }
+      { strictMode: true },
     ),
   ],
   ModVar4 = [
@@ -323,7 +323,7 @@ export default class ProjectStatusComponent extends Component<ProjectStatusSig> 
       <Icon @type={{this.iconType}} @id={{this.iconId}} />
       {{@project.status}}{{if this.restartProject.isRunning \\"...\\"}}
     </Button>\`,
-    { strictMode: true }
+    { strictMode: true },
   )]
 
   @service private declare server: ServerService;
@@ -370,7 +370,7 @@ class MyComponent extends Component<Signature> {
       Class top level template. Class top level template. Class top level
       template. Class top level template. Class top level template.
     </h1>\`,
-    { strictMode: true }
+    { strictMode: true },
   )]
 }
 "
@@ -395,7 +395,7 @@ class MyComponent extends Component<Signature> {
       Class top level template. Class top level template. Class top level
       template. Class top level template. Class top level template.
     </h1>\`,
-    { strictMode: true }
+    { strictMode: true },
   )]
 
   what = \`template literal that is not a template\`;
@@ -418,7 +418,7 @@ export interface Signature {
     module top level component. Explicit default export module top level
     component. Explicit default export module top level component. Explicit
     default export module top level component.\`,
-    { strictMode: true }
+    { strictMode: true },
   ),
 ] as TemplateOnlyComponent<Signature>
 "
@@ -438,7 +438,7 @@ export const Exported: TemplateOnlyComponent<Signature> = [
     \`Exported variable template. Exported variable template. Exported variable
     template. Exported variable template. Exported variable template. Exported
     variable template. Exported variable template.\`,
-    { strictMode: true }
+    { strictMode: true },
   ),
 ];
 "
@@ -458,7 +458,7 @@ export const Exported = [
     \`Exported variable template. Exported variable template. Exported variable
     template. Exported variable template. Exported variable template. Exported
     variable template. Exported variable template.\`,
-    { strictMode: true }
+    { strictMode: true },
   ),
 ] as TemplateOnlyComponent<Signature>;
 "
@@ -483,7 +483,7 @@ const Private: TemplateOnlyComponent<Signature> = [
     \`Private variable template. Private variable template. Private variable
     template. Private variable template. Private variable template. Private
     variable template. Private variable template.\`,
-    { strictMode: true }
+    { strictMode: true },
   ),
 ];
 "
@@ -503,7 +503,7 @@ const Private = [
     \`Private variable template. Private variable template. Private variable
     template. Private variable template. Private variable template. Private
     variable template. Private variable template.\`,
-    { strictMode: true }
+    { strictMode: true },
   ),
 ] as TemplateOnlyComponent<Signature>;
 "
@@ -525,7 +525,7 @@ const ModVar1: TemplateOnlyComponent<Signature> = [
         template. Module variable template. Module variable template. Module
         variable template. Module variable template. Module variable template.
       </h1>\`,
-      { strictMode: true }
+      { strictMode: true },
     ),
   ],
   ModVar2: TemplateOnlyComponent<Signature> = [
@@ -543,7 +543,7 @@ const bool: boolean = false,
         template. Module variable template. Module variable template. Module
         variable template. Module variable template. Module variable template.
       </h1>\`,
-      { strictMode: true }
+      { strictMode: true },
     ),
   ],
   ModVar4: TemplateOnlyComponent<Signature> = [
@@ -570,7 +570,7 @@ const ModVar1 = [
         template. Module variable template. Module variable template. Module
         variable template. Module variable template. Module variable template.
       </h1>\`,
-      { strictMode: true }
+      { strictMode: true },
     ),
   ] as TemplateOnlyComponent<Signature>,
   ModVar2 = [
@@ -588,7 +588,7 @@ const bool: boolean = false,
         template. Module variable template. Module variable template. Module
         variable template. Module variable template. Module variable template.
       </h1>\`,
-      { strictMode: true }
+      { strictMode: true },
     ),
   ] as TemplateOnlyComponent<Signature>,
   ModVar4 = [

--- a/tests/unit-tests/ambiguous/__snapshots__/arrow-parens-avoid.test.ts.snap
+++ b/tests/unit-tests/ambiguous/__snapshots__/arrow-parens-avoid.test.ts.snap
@@ -11,28 +11,7 @@ exports[`ambiguous > config > arrowParens: "avoid" > (oh, no) => {} > with semi,
 "
 `;
 
-exports[`ambiguous > config > arrowParens: "avoid" > (oh, no) => {} > with semi, with newline > it formats ../cases/gjs/default-export.gjs 2`] = `
-"<template>
-  Explicit default export module top level component. Explicit default export
-  module top level component. Explicit default export module top level
-  component. Explicit default export module top level component. Explicit
-  default export module top level component.
-</template>;
-(oh, no) => {};
-"
-`;
-
 exports[`ambiguous > config > arrowParens: "avoid" > (oh, no) => {} > with semi, with newline > it formats ../cases/gjs/exported-mod-var.gjs 1`] = `
-"export const Exported = <template>
-  Exported variable template. Exported variable template. Exported variable
-  template. Exported variable template. Exported variable template. Exported
-  variable template. Exported variable template.
-</template>;
-(oh, no) => {};
-"
-`;
-
-exports[`ambiguous > config > arrowParens: "avoid" > (oh, no) => {} > with semi, with newline > it formats ../cases/gjs/exported-mod-var.gjs 2`] = `
 "export const Exported = <template>
   Exported variable template. Exported variable template. Exported variable
   template. Exported variable template. Exported variable template. Exported
@@ -48,26 +27,7 @@ exports[`ambiguous > config > arrowParens: "avoid" > (oh, no) => {} > with semi,
 "
 `;
 
-exports[`ambiguous > config > arrowParens: "avoid" > (oh, no) => {} > with semi, with newline > it formats ../cases/gjs/js-only.gjs 2`] = `
-"const num = 1;
-(oh, no) => {};
-"
-`;
-
 exports[`ambiguous > config > arrowParens: "avoid" > (oh, no) => {} > with semi, with newline > it formats ../cases/gjs/mod-var.gjs 1`] = `
-"const Private = <template>
-  Private variable template. Private variable template. Private variable
-  template. Private variable template. Private variable template. Private
-  variable template. Private variable template.
-</template>;
-(oh, no) => {};
-
-const What = <template>Hi</template>;
-(oh, no) => {};
-"
-`;
-
-exports[`ambiguous > config > arrowParens: "avoid" > (oh, no) => {} > with semi, with newline > it formats ../cases/gjs/mod-var.gjs 2`] = `
 "const Private = <template>
   Private variable template. Private variable template. Private variable
   template. Private variable template. Private variable template. Private
@@ -105,31 +65,6 @@ const bool = false,
 "
 `;
 
-exports[`ambiguous > config > arrowParens: "avoid" > (oh, no) => {} > with semi, with newline > it formats ../cases/gjs/multiple-declarations.gjs 2`] = `
-"const ModVar1 = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template>,
-  ModVar2 = <template>Second module variable template.</template>,
-  num = 1;
-(oh, no) => {};
-
-const bool = false,
-  ModVar3 = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template>,
-  ModVar4 = <template>Second module variable template.</template>;
-(oh, no) => {};
-"
-`;
-
 exports[`ambiguous > config > arrowParens: "avoid" > (oh, no) => {} > with semi, with newline > it formats ../cases/gjs/simple.gjs 1`] = `
 "<template>
   what
@@ -138,34 +73,7 @@ exports[`ambiguous > config > arrowParens: "avoid" > (oh, no) => {} > with semi,
 "
 `;
 
-exports[`ambiguous > config > arrowParens: "avoid" > (oh, no) => {} > with semi, with newline > it formats ../cases/gjs/simple.gjs 2`] = `
-"<template>
-  what
-</template>;
-(oh, no) => {};
-"
-`;
-
 exports[`ambiguous > config > arrowParens: "avoid" > (oh, no) => {} > with semi, with newline > it formats ../cases/gts/default-export.gts 1`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
-
-export interface Signature {
-  Element: HTMLElement;
-  Args: {};
-  Yields: [];
-}
-
-<template>
-  Explicit default export module top level component. Explicit default export
-  module top level component. Explicit default export module top level
-  component. Explicit default export module top level component. Explicit
-  default export module top level component.
-</template> as TemplateOnlyComponent<Signature>;
-(oh, no) => {};
-"
-`;
-
-exports[`ambiguous > config > arrowParens: "avoid" > (oh, no) => {} > with semi, with newline > it formats ../cases/gts/default-export.gts 2`] = `
 "import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
 
 export interface Signature {
@@ -202,43 +110,7 @@ export const Exported: TemplateOnlyComponent<Signature> = <template>
 "
 `;
 
-exports[`ambiguous > config > arrowParens: "avoid" > (oh, no) => {} > with semi, with newline > it formats ../cases/gts/exported-mod-var.gts 2`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
-
-export interface Signature {
-  Element: HTMLElement;
-  Args: {};
-  Yields: [];
-}
-
-export const Exported: TemplateOnlyComponent<Signature> = <template>
-  Exported variable template. Exported variable template. Exported variable
-  template. Exported variable template. Exported variable template. Exported
-  variable template. Exported variable template.
-</template>;
-(oh, no) => {};
-"
-`;
-
 exports[`ambiguous > config > arrowParens: "avoid" > (oh, no) => {} > with semi, with newline > it formats ../cases/gts/exported-mod-var-with-as.gts 1`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
-
-export interface Signature {
-  Element: HTMLElement;
-  Args: {};
-  Yields: [];
-}
-
-export const Exported = <template>
-  Exported variable template. Exported variable template. Exported variable
-  template. Exported variable template. Exported variable template. Exported
-  variable template. Exported variable template.
-</template> as TemplateOnlyComponent<Signature>;
-(oh, no) => {};
-"
-`;
-
-exports[`ambiguous > config > arrowParens: "avoid" > (oh, no) => {} > with semi, with newline > it formats ../cases/gts/exported-mod-var-with-as.gts 2`] = `
 "import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
 
 export interface Signature {
@@ -262,31 +134,7 @@ exports[`ambiguous > config > arrowParens: "avoid" > (oh, no) => {} > with semi,
 "
 `;
 
-exports[`ambiguous > config > arrowParens: "avoid" > (oh, no) => {} > with semi, with newline > it formats ../cases/gts/js-only.gts 2`] = `
-"const num: number = 1;
-(oh, no) => {};
-"
-`;
-
 exports[`ambiguous > config > arrowParens: "avoid" > (oh, no) => {} > with semi, with newline > it formats ../cases/gts/mod-var.gts 1`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
-
-export interface Signature {
-  Element: HTMLElement;
-  Args: {};
-  Yields: [];
-}
-
-const Private: TemplateOnlyComponent<Signature> = <template>
-  Private variable template. Private variable template. Private variable
-  template. Private variable template. Private variable template. Private
-  variable template. Private variable template.
-</template>;
-(oh, no) => {};
-"
-`;
-
-exports[`ambiguous > config > arrowParens: "avoid" > (oh, no) => {} > with semi, with newline > it formats ../cases/gts/mod-var.gts 2`] = `
 "import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
 
 export interface Signature {
@@ -322,62 +170,7 @@ const Private = <template>
 "
 `;
 
-exports[`ambiguous > config > arrowParens: "avoid" > (oh, no) => {} > with semi, with newline > it formats ../cases/gts/mod-var-with-as.gts 2`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
-
-export interface Signature {
-  Element: HTMLElement;
-  Args: {};
-  Yields: [];
-}
-
-const Private = <template>
-  Private variable template. Private variable template. Private variable
-  template. Private variable template. Private variable template. Private
-  variable template. Private variable template.
-</template> as TemplateOnlyComponent<Signature>;
-(oh, no) => {};
-"
-`;
-
 exports[`ambiguous > config > arrowParens: "avoid" > (oh, no) => {} > with semi, with newline > it formats ../cases/gts/multiple-declarations.gts 1`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
-
-export interface Signature {
-  Element: HTMLElement;
-  Args: {};
-  Yields: [];
-}
-
-const ModVar1: TemplateOnlyComponent<Signature> = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template>,
-  ModVar2: TemplateOnlyComponent<Signature> = <template>
-    Second module variable template.
-  </template>,
-  num = 1;
-(oh, no) => {};
-
-const bool: boolean = false,
-  ModVar3: TemplateOnlyComponent<Signature> = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template>,
-  ModVar4: TemplateOnlyComponent<Signature> = <template>
-    Second module variable template.
-  </template>;
-(oh, no) => {};
-"
-`;
-
-exports[`ambiguous > config > arrowParens: "avoid" > (oh, no) => {} > with semi, with newline > it formats ../cases/gts/multiple-declarations.gts 2`] = `
 "import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
 
 export interface Signature {
@@ -451,60 +244,7 @@ const bool: boolean = false,
 "
 `;
 
-exports[`ambiguous > config > arrowParens: "avoid" > (oh, no) => {} > with semi, with newline > it formats ../cases/gts/multiple-declarations-with-as.gts 2`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
-
-export interface Signature {
-  Element: HTMLElement;
-  Args: {};
-  Yields: [];
-}
-
-const ModVar1 = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template> as TemplateOnlyComponent<Signature>,
-  ModVar2 = <template>
-    Second module variable template.
-  </template> as TemplateOnlyComponent<Signature>,
-  num = 1;
-(oh, no) => {};
-
-const bool: boolean = false,
-  ModVar3 = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template> as TemplateOnlyComponent<Signature>,
-  ModVar4 = <template>
-    Second module variable template.
-  </template> as TemplateOnlyComponent<Signature>;
-(oh, no) => {};
-"
-`;
-
 exports[`ambiguous > config > arrowParens: "avoid" > (oh, no) => {} > with semi, with newline > it formats ../cases/gts/simple.gts 1`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
-
-export interface Signature {
-  Element: HTMLElement;
-  Args: {};
-  Yields: [];
-}
-
-<template>
-  what
-</template> as TemplateOnlyComponent<Signature>;
-(oh, no) => {};
-"
-`;
-
-exports[`ambiguous > config > arrowParens: "avoid" > (oh, no) => {} > with semi, with newline > it formats ../cases/gts/simple.gts 2`] = `
 "import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
 
 export interface Signature {
@@ -929,28 +669,7 @@ oops => {};
 "
 `;
 
-exports[`ambiguous > config > arrowParens: "avoid" > (oops) => {} > with semi, with newline > it formats ../cases/gjs/default-export.gjs 2`] = `
-"<template>
-  Explicit default export module top level component. Explicit default export
-  module top level component. Explicit default export module top level
-  component. Explicit default export module top level component. Explicit
-  default export module top level component.
-</template>
-oops => {};
-"
-`;
-
 exports[`ambiguous > config > arrowParens: "avoid" > (oops) => {} > with semi, with newline > it formats ../cases/gjs/exported-mod-var.gjs 1`] = `
-"export const Exported = <template>
-  Exported variable template. Exported variable template. Exported variable
-  template. Exported variable template. Exported variable template. Exported
-  variable template. Exported variable template.
-</template>;
-oops => {};
-"
-`;
-
-exports[`ambiguous > config > arrowParens: "avoid" > (oops) => {} > with semi, with newline > it formats ../cases/gjs/exported-mod-var.gjs 2`] = `
 "export const Exported = <template>
   Exported variable template. Exported variable template. Exported variable
   template. Exported variable template. Exported variable template. Exported
@@ -966,26 +685,7 @@ oops => {};
 "
 `;
 
-exports[`ambiguous > config > arrowParens: "avoid" > (oops) => {} > with semi, with newline > it formats ../cases/gjs/js-only.gjs 2`] = `
-"const num = 1;
-oops => {};
-"
-`;
-
 exports[`ambiguous > config > arrowParens: "avoid" > (oops) => {} > with semi, with newline > it formats ../cases/gjs/mod-var.gjs 1`] = `
-"const Private = <template>
-  Private variable template. Private variable template. Private variable
-  template. Private variable template. Private variable template. Private
-  variable template. Private variable template.
-</template>;
-oops => {};
-
-const What = <template>Hi</template>;
-oops => {};
-"
-`;
-
-exports[`ambiguous > config > arrowParens: "avoid" > (oops) => {} > with semi, with newline > it formats ../cases/gjs/mod-var.gjs 2`] = `
 "const Private = <template>
   Private variable template. Private variable template. Private variable
   template. Private variable template. Private variable template. Private
@@ -1023,31 +723,6 @@ oops => {};
 "
 `;
 
-exports[`ambiguous > config > arrowParens: "avoid" > (oops) => {} > with semi, with newline > it formats ../cases/gjs/multiple-declarations.gjs 2`] = `
-"const ModVar1 = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template>,
-  ModVar2 = <template>Second module variable template.</template>,
-  num = 1;
-oops => {};
-
-const bool = false,
-  ModVar3 = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template>,
-  ModVar4 = <template>Second module variable template.</template>;
-oops => {};
-"
-`;
-
 exports[`ambiguous > config > arrowParens: "avoid" > (oops) => {} > with semi, with newline > it formats ../cases/gjs/simple.gjs 1`] = `
 "<template>
   what
@@ -1056,34 +731,7 @@ oops => {};
 "
 `;
 
-exports[`ambiguous > config > arrowParens: "avoid" > (oops) => {} > with semi, with newline > it formats ../cases/gjs/simple.gjs 2`] = `
-"<template>
-  what
-</template>
-oops => {};
-"
-`;
-
 exports[`ambiguous > config > arrowParens: "avoid" > (oops) => {} > with semi, with newline > it formats ../cases/gts/default-export.gts 1`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
-
-export interface Signature {
-  Element: HTMLElement;
-  Args: {};
-  Yields: [];
-}
-
-<template>
-  Explicit default export module top level component. Explicit default export
-  module top level component. Explicit default export module top level
-  component. Explicit default export module top level component. Explicit
-  default export module top level component.
-</template> as TemplateOnlyComponent<Signature>
-oops => {};
-"
-`;
-
-exports[`ambiguous > config > arrowParens: "avoid" > (oops) => {} > with semi, with newline > it formats ../cases/gts/default-export.gts 2`] = `
 "import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
 
 export interface Signature {
@@ -1120,43 +768,7 @@ oops => {};
 "
 `;
 
-exports[`ambiguous > config > arrowParens: "avoid" > (oops) => {} > with semi, with newline > it formats ../cases/gts/exported-mod-var.gts 2`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
-
-export interface Signature {
-  Element: HTMLElement;
-  Args: {};
-  Yields: [];
-}
-
-export const Exported: TemplateOnlyComponent<Signature> = <template>
-  Exported variable template. Exported variable template. Exported variable
-  template. Exported variable template. Exported variable template. Exported
-  variable template. Exported variable template.
-</template>;
-oops => {};
-"
-`;
-
 exports[`ambiguous > config > arrowParens: "avoid" > (oops) => {} > with semi, with newline > it formats ../cases/gts/exported-mod-var-with-as.gts 1`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
-
-export interface Signature {
-  Element: HTMLElement;
-  Args: {};
-  Yields: [];
-}
-
-export const Exported = <template>
-  Exported variable template. Exported variable template. Exported variable
-  template. Exported variable template. Exported variable template. Exported
-  variable template. Exported variable template.
-</template> as TemplateOnlyComponent<Signature>;
-oops => {};
-"
-`;
-
-exports[`ambiguous > config > arrowParens: "avoid" > (oops) => {} > with semi, with newline > it formats ../cases/gts/exported-mod-var-with-as.gts 2`] = `
 "import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
 
 export interface Signature {
@@ -1180,31 +792,7 @@ oops => {};
 "
 `;
 
-exports[`ambiguous > config > arrowParens: "avoid" > (oops) => {} > with semi, with newline > it formats ../cases/gts/js-only.gts 2`] = `
-"const num: number = 1;
-oops => {};
-"
-`;
-
 exports[`ambiguous > config > arrowParens: "avoid" > (oops) => {} > with semi, with newline > it formats ../cases/gts/mod-var.gts 1`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
-
-export interface Signature {
-  Element: HTMLElement;
-  Args: {};
-  Yields: [];
-}
-
-const Private: TemplateOnlyComponent<Signature> = <template>
-  Private variable template. Private variable template. Private variable
-  template. Private variable template. Private variable template. Private
-  variable template. Private variable template.
-</template>;
-oops => {};
-"
-`;
-
-exports[`ambiguous > config > arrowParens: "avoid" > (oops) => {} > with semi, with newline > it formats ../cases/gts/mod-var.gts 2`] = `
 "import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
 
 export interface Signature {
@@ -1240,62 +828,7 @@ oops => {};
 "
 `;
 
-exports[`ambiguous > config > arrowParens: "avoid" > (oops) => {} > with semi, with newline > it formats ../cases/gts/mod-var-with-as.gts 2`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
-
-export interface Signature {
-  Element: HTMLElement;
-  Args: {};
-  Yields: [];
-}
-
-const Private = <template>
-  Private variable template. Private variable template. Private variable
-  template. Private variable template. Private variable template. Private
-  variable template. Private variable template.
-</template> as TemplateOnlyComponent<Signature>;
-oops => {};
-"
-`;
-
 exports[`ambiguous > config > arrowParens: "avoid" > (oops) => {} > with semi, with newline > it formats ../cases/gts/multiple-declarations.gts 1`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
-
-export interface Signature {
-  Element: HTMLElement;
-  Args: {};
-  Yields: [];
-}
-
-const ModVar1: TemplateOnlyComponent<Signature> = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template>,
-  ModVar2: TemplateOnlyComponent<Signature> = <template>
-    Second module variable template.
-  </template>,
-  num = 1;
-oops => {};
-
-const bool: boolean = false,
-  ModVar3: TemplateOnlyComponent<Signature> = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template>,
-  ModVar4: TemplateOnlyComponent<Signature> = <template>
-    Second module variable template.
-  </template>;
-oops => {};
-"
-`;
-
-exports[`ambiguous > config > arrowParens: "avoid" > (oops) => {} > with semi, with newline > it formats ../cases/gts/multiple-declarations.gts 2`] = `
 "import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
 
 export interface Signature {
@@ -1369,60 +902,7 @@ oops => {};
 "
 `;
 
-exports[`ambiguous > config > arrowParens: "avoid" > (oops) => {} > with semi, with newline > it formats ../cases/gts/multiple-declarations-with-as.gts 2`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
-
-export interface Signature {
-  Element: HTMLElement;
-  Args: {};
-  Yields: [];
-}
-
-const ModVar1 = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template> as TemplateOnlyComponent<Signature>,
-  ModVar2 = <template>
-    Second module variable template.
-  </template> as TemplateOnlyComponent<Signature>,
-  num = 1;
-oops => {};
-
-const bool: boolean = false,
-  ModVar3 = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template> as TemplateOnlyComponent<Signature>,
-  ModVar4 = <template>
-    Second module variable template.
-  </template> as TemplateOnlyComponent<Signature>;
-oops => {};
-"
-`;
-
 exports[`ambiguous > config > arrowParens: "avoid" > (oops) => {} > with semi, with newline > it formats ../cases/gts/simple.gts 1`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
-
-export interface Signature {
-  Element: HTMLElement;
-  Args: {};
-  Yields: [];
-}
-
-<template>
-  what
-</template> as TemplateOnlyComponent<Signature>
-oops => {};
-"
-`;
-
-exports[`ambiguous > config > arrowParens: "avoid" > (oops) => {} > with semi, with newline > it formats ../cases/gts/simple.gts 2`] = `
 "import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
 
 export interface Signature {

--- a/tests/unit-tests/ambiguous/__snapshots__/arrow-parens-avoid.test.ts.snap
+++ b/tests/unit-tests/ambiguous/__snapshots__/arrow-parens-avoid.test.ts.snap
@@ -520,6 +520,266 @@ export interface Signature {
 "
 `;
 
+exports[`ambiguous > config > arrowParens: "avoid" > (oh, no) => {} > with semi, without newline > it formats ../cases/gjs/default-export.gjs 1`] = `
+"<template>
+  Explicit default export module top level component. Explicit default export
+  module top level component. Explicit default export module top level
+  component. Explicit default export module top level component. Explicit
+  default export module top level component.
+</template>;
+(oh, no) => {};
+"
+`;
+
+exports[`ambiguous > config > arrowParens: "avoid" > (oh, no) => {} > with semi, without newline > it formats ../cases/gjs/exported-mod-var.gjs 1`] = `
+"export const Exported = <template>
+  Exported variable template. Exported variable template. Exported variable
+  template. Exported variable template. Exported variable template. Exported
+  variable template. Exported variable template.
+</template>;
+(oh, no) => {};
+"
+`;
+
+exports[`ambiguous > config > arrowParens: "avoid" > (oh, no) => {} > with semi, without newline > it formats ../cases/gjs/js-only.gjs 1`] = `
+"const num = 1;
+(oh, no) => {};
+"
+`;
+
+exports[`ambiguous > config > arrowParens: "avoid" > (oh, no) => {} > with semi, without newline > it formats ../cases/gjs/mod-var.gjs 1`] = `
+"const Private = <template>
+  Private variable template. Private variable template. Private variable
+  template. Private variable template. Private variable template. Private
+  variable template. Private variable template.
+</template>;
+(oh, no) => {};
+
+const What = <template>Hi</template>;
+(oh, no) => {};
+"
+`;
+
+exports[`ambiguous > config > arrowParens: "avoid" > (oh, no) => {} > with semi, without newline > it formats ../cases/gjs/multiple-declarations.gjs 1`] = `
+"const ModVar1 = <template>
+    <h1>
+      Module variable template. Module variable template. Module variable
+      template. Module variable template. Module variable template. Module
+      variable template. Module variable template. Module variable template.
+    </h1>
+  </template>,
+  ModVar2 = <template>Second module variable template.</template>,
+  num = 1;
+(oh, no) => {};
+
+const bool = false,
+  ModVar3 = <template>
+    <h1>
+      Module variable template. Module variable template. Module variable
+      template. Module variable template. Module variable template. Module
+      variable template. Module variable template. Module variable template.
+    </h1>
+  </template>,
+  ModVar4 = <template>Second module variable template.</template>;
+(oh, no) => {};
+"
+`;
+
+exports[`ambiguous > config > arrowParens: "avoid" > (oh, no) => {} > with semi, without newline > it formats ../cases/gjs/simple.gjs 1`] = `
+"<template>
+  what
+</template>;
+(oh, no) => {};
+"
+`;
+
+exports[`ambiguous > config > arrowParens: "avoid" > (oh, no) => {} > with semi, without newline > it formats ../cases/gts/default-export.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
+
+export interface Signature {
+  Element: HTMLElement;
+  Args: {};
+  Yields: [];
+}
+
+<template>
+  Explicit default export module top level component. Explicit default export
+  module top level component. Explicit default export module top level
+  component. Explicit default export module top level component. Explicit
+  default export module top level component.
+</template> as TemplateOnlyComponent<Signature>;
+(oh, no) => {};
+"
+`;
+
+exports[`ambiguous > config > arrowParens: "avoid" > (oh, no) => {} > with semi, without newline > it formats ../cases/gts/exported-mod-var.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
+
+export interface Signature {
+  Element: HTMLElement;
+  Args: {};
+  Yields: [];
+}
+
+export const Exported: TemplateOnlyComponent<Signature> = <template>
+  Exported variable template. Exported variable template. Exported variable
+  template. Exported variable template. Exported variable template. Exported
+  variable template. Exported variable template.
+</template>;
+(oh, no) => {};
+"
+`;
+
+exports[`ambiguous > config > arrowParens: "avoid" > (oh, no) => {} > with semi, without newline > it formats ../cases/gts/exported-mod-var-with-as.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
+
+export interface Signature {
+  Element: HTMLElement;
+  Args: {};
+  Yields: [];
+}
+
+export const Exported = <template>
+  Exported variable template. Exported variable template. Exported variable
+  template. Exported variable template. Exported variable template. Exported
+  variable template. Exported variable template.
+</template> as TemplateOnlyComponent<Signature>;
+(oh, no) => {};
+"
+`;
+
+exports[`ambiguous > config > arrowParens: "avoid" > (oh, no) => {} > with semi, without newline > it formats ../cases/gts/js-only.gts 1`] = `
+"const num: number = 1;
+(oh, no) => {};
+"
+`;
+
+exports[`ambiguous > config > arrowParens: "avoid" > (oh, no) => {} > with semi, without newline > it formats ../cases/gts/mod-var.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
+
+export interface Signature {
+  Element: HTMLElement;
+  Args: {};
+  Yields: [];
+}
+
+const Private: TemplateOnlyComponent<Signature> = <template>
+  Private variable template. Private variable template. Private variable
+  template. Private variable template. Private variable template. Private
+  variable template. Private variable template.
+</template>;
+(oh, no) => {};
+"
+`;
+
+exports[`ambiguous > config > arrowParens: "avoid" > (oh, no) => {} > with semi, without newline > it formats ../cases/gts/mod-var-with-as.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
+
+export interface Signature {
+  Element: HTMLElement;
+  Args: {};
+  Yields: [];
+}
+
+const Private = <template>
+  Private variable template. Private variable template. Private variable
+  template. Private variable template. Private variable template. Private
+  variable template. Private variable template.
+</template> as TemplateOnlyComponent<Signature>;
+(oh, no) => {};
+"
+`;
+
+exports[`ambiguous > config > arrowParens: "avoid" > (oh, no) => {} > with semi, without newline > it formats ../cases/gts/multiple-declarations.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
+
+export interface Signature {
+  Element: HTMLElement;
+  Args: {};
+  Yields: [];
+}
+
+const ModVar1: TemplateOnlyComponent<Signature> = <template>
+    <h1>
+      Module variable template. Module variable template. Module variable
+      template. Module variable template. Module variable template. Module
+      variable template. Module variable template. Module variable template.
+    </h1>
+  </template>,
+  ModVar2: TemplateOnlyComponent<Signature> = <template>
+    Second module variable template.
+  </template>,
+  num = 1;
+(oh, no) => {};
+
+const bool: boolean = false,
+  ModVar3: TemplateOnlyComponent<Signature> = <template>
+    <h1>
+      Module variable template. Module variable template. Module variable
+      template. Module variable template. Module variable template. Module
+      variable template. Module variable template. Module variable template.
+    </h1>
+  </template>,
+  ModVar4: TemplateOnlyComponent<Signature> = <template>
+    Second module variable template.
+  </template>;
+(oh, no) => {};
+"
+`;
+
+exports[`ambiguous > config > arrowParens: "avoid" > (oh, no) => {} > with semi, without newline > it formats ../cases/gts/multiple-declarations-with-as.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
+
+export interface Signature {
+  Element: HTMLElement;
+  Args: {};
+  Yields: [];
+}
+
+const ModVar1 = <template>
+    <h1>
+      Module variable template. Module variable template. Module variable
+      template. Module variable template. Module variable template. Module
+      variable template. Module variable template. Module variable template.
+    </h1>
+  </template> as TemplateOnlyComponent<Signature>,
+  ModVar2 = <template>
+    Second module variable template.
+  </template> as TemplateOnlyComponent<Signature>,
+  num = 1;
+(oh, no) => {};
+
+const bool: boolean = false,
+  ModVar3 = <template>
+    <h1>
+      Module variable template. Module variable template. Module variable
+      template. Module variable template. Module variable template. Module
+      variable template. Module variable template. Module variable template.
+    </h1>
+  </template> as TemplateOnlyComponent<Signature>,
+  ModVar4 = <template>
+    Second module variable template.
+  </template> as TemplateOnlyComponent<Signature>;
+(oh, no) => {};
+"
+`;
+
+exports[`ambiguous > config > arrowParens: "avoid" > (oh, no) => {} > with semi, without newline > it formats ../cases/gts/simple.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
+
+export interface Signature {
+  Element: HTMLElement;
+  Args: {};
+  Yields: [];
+}
+
+<template>
+  what
+</template> as TemplateOnlyComponent<Signature>;
+(oh, no) => {};
+"
+`;
+
 exports[`ambiguous > config > arrowParens: "avoid" > (oh, no) => {} > without semi, with newline > it formats ../cases/gts/default-export.gts 1`] = `
 "import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
 
@@ -1163,6 +1423,266 @@ oops => {};
 `;
 
 exports[`ambiguous > config > arrowParens: "avoid" > (oops) => {} > with semi, with newline > it formats ../cases/gts/simple.gts 2`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
+
+export interface Signature {
+  Element: HTMLElement;
+  Args: {};
+  Yields: [];
+}
+
+<template>
+  what
+</template> as TemplateOnlyComponent<Signature>
+oops => {};
+"
+`;
+
+exports[`ambiguous > config > arrowParens: "avoid" > (oops) => {} > with semi, without newline > it formats ../cases/gjs/default-export.gjs 1`] = `
+"<template>
+  Explicit default export module top level component. Explicit default export
+  module top level component. Explicit default export module top level
+  component. Explicit default export module top level component. Explicit
+  default export module top level component.
+</template>
+oops => {};
+"
+`;
+
+exports[`ambiguous > config > arrowParens: "avoid" > (oops) => {} > with semi, without newline > it formats ../cases/gjs/exported-mod-var.gjs 1`] = `
+"export const Exported = <template>
+  Exported variable template. Exported variable template. Exported variable
+  template. Exported variable template. Exported variable template. Exported
+  variable template. Exported variable template.
+</template>;
+oops => {};
+"
+`;
+
+exports[`ambiguous > config > arrowParens: "avoid" > (oops) => {} > with semi, without newline > it formats ../cases/gjs/js-only.gjs 1`] = `
+"const num = 1;
+oops => {};
+"
+`;
+
+exports[`ambiguous > config > arrowParens: "avoid" > (oops) => {} > with semi, without newline > it formats ../cases/gjs/mod-var.gjs 1`] = `
+"const Private = <template>
+  Private variable template. Private variable template. Private variable
+  template. Private variable template. Private variable template. Private
+  variable template. Private variable template.
+</template>;
+oops => {};
+
+const What = <template>Hi</template>;
+oops => {};
+"
+`;
+
+exports[`ambiguous > config > arrowParens: "avoid" > (oops) => {} > with semi, without newline > it formats ../cases/gjs/multiple-declarations.gjs 1`] = `
+"const ModVar1 = <template>
+    <h1>
+      Module variable template. Module variable template. Module variable
+      template. Module variable template. Module variable template. Module
+      variable template. Module variable template. Module variable template.
+    </h1>
+  </template>,
+  ModVar2 = <template>Second module variable template.</template>,
+  num = 1;
+oops => {};
+
+const bool = false,
+  ModVar3 = <template>
+    <h1>
+      Module variable template. Module variable template. Module variable
+      template. Module variable template. Module variable template. Module
+      variable template. Module variable template. Module variable template.
+    </h1>
+  </template>,
+  ModVar4 = <template>Second module variable template.</template>;
+oops => {};
+"
+`;
+
+exports[`ambiguous > config > arrowParens: "avoid" > (oops) => {} > with semi, without newline > it formats ../cases/gjs/simple.gjs 1`] = `
+"<template>
+  what
+</template>
+oops => {};
+"
+`;
+
+exports[`ambiguous > config > arrowParens: "avoid" > (oops) => {} > with semi, without newline > it formats ../cases/gts/default-export.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
+
+export interface Signature {
+  Element: HTMLElement;
+  Args: {};
+  Yields: [];
+}
+
+<template>
+  Explicit default export module top level component. Explicit default export
+  module top level component. Explicit default export module top level
+  component. Explicit default export module top level component. Explicit
+  default export module top level component.
+</template> as TemplateOnlyComponent<Signature>
+oops => {};
+"
+`;
+
+exports[`ambiguous > config > arrowParens: "avoid" > (oops) => {} > with semi, without newline > it formats ../cases/gts/exported-mod-var.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
+
+export interface Signature {
+  Element: HTMLElement;
+  Args: {};
+  Yields: [];
+}
+
+export const Exported: TemplateOnlyComponent<Signature> = <template>
+  Exported variable template. Exported variable template. Exported variable
+  template. Exported variable template. Exported variable template. Exported
+  variable template. Exported variable template.
+</template>;
+oops => {};
+"
+`;
+
+exports[`ambiguous > config > arrowParens: "avoid" > (oops) => {} > with semi, without newline > it formats ../cases/gts/exported-mod-var-with-as.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
+
+export interface Signature {
+  Element: HTMLElement;
+  Args: {};
+  Yields: [];
+}
+
+export const Exported = <template>
+  Exported variable template. Exported variable template. Exported variable
+  template. Exported variable template. Exported variable template. Exported
+  variable template. Exported variable template.
+</template> as TemplateOnlyComponent<Signature>;
+oops => {};
+"
+`;
+
+exports[`ambiguous > config > arrowParens: "avoid" > (oops) => {} > with semi, without newline > it formats ../cases/gts/js-only.gts 1`] = `
+"const num: number = 1;
+oops => {};
+"
+`;
+
+exports[`ambiguous > config > arrowParens: "avoid" > (oops) => {} > with semi, without newline > it formats ../cases/gts/mod-var.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
+
+export interface Signature {
+  Element: HTMLElement;
+  Args: {};
+  Yields: [];
+}
+
+const Private: TemplateOnlyComponent<Signature> = <template>
+  Private variable template. Private variable template. Private variable
+  template. Private variable template. Private variable template. Private
+  variable template. Private variable template.
+</template>;
+oops => {};
+"
+`;
+
+exports[`ambiguous > config > arrowParens: "avoid" > (oops) => {} > with semi, without newline > it formats ../cases/gts/mod-var-with-as.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
+
+export interface Signature {
+  Element: HTMLElement;
+  Args: {};
+  Yields: [];
+}
+
+const Private = <template>
+  Private variable template. Private variable template. Private variable
+  template. Private variable template. Private variable template. Private
+  variable template. Private variable template.
+</template> as TemplateOnlyComponent<Signature>;
+oops => {};
+"
+`;
+
+exports[`ambiguous > config > arrowParens: "avoid" > (oops) => {} > with semi, without newline > it formats ../cases/gts/multiple-declarations.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
+
+export interface Signature {
+  Element: HTMLElement;
+  Args: {};
+  Yields: [];
+}
+
+const ModVar1: TemplateOnlyComponent<Signature> = <template>
+    <h1>
+      Module variable template. Module variable template. Module variable
+      template. Module variable template. Module variable template. Module
+      variable template. Module variable template. Module variable template.
+    </h1>
+  </template>,
+  ModVar2: TemplateOnlyComponent<Signature> = <template>
+    Second module variable template.
+  </template>,
+  num = 1;
+oops => {};
+
+const bool: boolean = false,
+  ModVar3: TemplateOnlyComponent<Signature> = <template>
+    <h1>
+      Module variable template. Module variable template. Module variable
+      template. Module variable template. Module variable template. Module
+      variable template. Module variable template. Module variable template.
+    </h1>
+  </template>,
+  ModVar4: TemplateOnlyComponent<Signature> = <template>
+    Second module variable template.
+  </template>;
+oops => {};
+"
+`;
+
+exports[`ambiguous > config > arrowParens: "avoid" > (oops) => {} > with semi, without newline > it formats ../cases/gts/multiple-declarations-with-as.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
+
+export interface Signature {
+  Element: HTMLElement;
+  Args: {};
+  Yields: [];
+}
+
+const ModVar1 = <template>
+    <h1>
+      Module variable template. Module variable template. Module variable
+      template. Module variable template. Module variable template. Module
+      variable template. Module variable template. Module variable template.
+    </h1>
+  </template> as TemplateOnlyComponent<Signature>,
+  ModVar2 = <template>
+    Second module variable template.
+  </template> as TemplateOnlyComponent<Signature>,
+  num = 1;
+oops => {};
+
+const bool: boolean = false,
+  ModVar3 = <template>
+    <h1>
+      Module variable template. Module variable template. Module variable
+      template. Module variable template. Module variable template. Module
+      variable template. Module variable template. Module variable template.
+    </h1>
+  </template> as TemplateOnlyComponent<Signature>,
+  ModVar4 = <template>
+    Second module variable template.
+  </template> as TemplateOnlyComponent<Signature>;
+oops => {};
+"
+`;
+
+exports[`ambiguous > config > arrowParens: "avoid" > (oops) => {} > with semi, without newline > it formats ../cases/gts/simple.gts 1`] = `
 "import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
 
 export interface Signature {

--- a/tests/unit-tests/ambiguous/__snapshots__/index.test.ts.snap
+++ b/tests/unit-tests/ambiguous/__snapshots__/index.test.ts.snap
@@ -520,6 +520,266 @@ export interface Signature {
 "
 `;
 
+exports[`ambiguous > config > default > (oh, no) => {} > with semi, without newline > it formats ../cases/gjs/default-export.gjs 1`] = `
+"<template>
+  Explicit default export module top level component. Explicit default export
+  module top level component. Explicit default export module top level
+  component. Explicit default export module top level component. Explicit
+  default export module top level component.
+</template>;
+(oh, no) => {};
+"
+`;
+
+exports[`ambiguous > config > default > (oh, no) => {} > with semi, without newline > it formats ../cases/gjs/exported-mod-var.gjs 1`] = `
+"export const Exported = <template>
+  Exported variable template. Exported variable template. Exported variable
+  template. Exported variable template. Exported variable template. Exported
+  variable template. Exported variable template.
+</template>;
+(oh, no) => {};
+"
+`;
+
+exports[`ambiguous > config > default > (oh, no) => {} > with semi, without newline > it formats ../cases/gjs/js-only.gjs 1`] = `
+"const num = 1;
+(oh, no) => {};
+"
+`;
+
+exports[`ambiguous > config > default > (oh, no) => {} > with semi, without newline > it formats ../cases/gjs/mod-var.gjs 1`] = `
+"const Private = <template>
+  Private variable template. Private variable template. Private variable
+  template. Private variable template. Private variable template. Private
+  variable template. Private variable template.
+</template>;
+(oh, no) => {};
+
+const What = <template>Hi</template>;
+(oh, no) => {};
+"
+`;
+
+exports[`ambiguous > config > default > (oh, no) => {} > with semi, without newline > it formats ../cases/gjs/multiple-declarations.gjs 1`] = `
+"const ModVar1 = <template>
+    <h1>
+      Module variable template. Module variable template. Module variable
+      template. Module variable template. Module variable template. Module
+      variable template. Module variable template. Module variable template.
+    </h1>
+  </template>,
+  ModVar2 = <template>Second module variable template.</template>,
+  num = 1;
+(oh, no) => {};
+
+const bool = false,
+  ModVar3 = <template>
+    <h1>
+      Module variable template. Module variable template. Module variable
+      template. Module variable template. Module variable template. Module
+      variable template. Module variable template. Module variable template.
+    </h1>
+  </template>,
+  ModVar4 = <template>Second module variable template.</template>;
+(oh, no) => {};
+"
+`;
+
+exports[`ambiguous > config > default > (oh, no) => {} > with semi, without newline > it formats ../cases/gjs/simple.gjs 1`] = `
+"<template>
+  what
+</template>;
+(oh, no) => {};
+"
+`;
+
+exports[`ambiguous > config > default > (oh, no) => {} > with semi, without newline > it formats ../cases/gts/default-export.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
+
+export interface Signature {
+  Element: HTMLElement;
+  Args: {};
+  Yields: [];
+}
+
+<template>
+  Explicit default export module top level component. Explicit default export
+  module top level component. Explicit default export module top level
+  component. Explicit default export module top level component. Explicit
+  default export module top level component.
+</template> as TemplateOnlyComponent<Signature>;
+(oh, no) => {};
+"
+`;
+
+exports[`ambiguous > config > default > (oh, no) => {} > with semi, without newline > it formats ../cases/gts/exported-mod-var.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
+
+export interface Signature {
+  Element: HTMLElement;
+  Args: {};
+  Yields: [];
+}
+
+export const Exported: TemplateOnlyComponent<Signature> = <template>
+  Exported variable template. Exported variable template. Exported variable
+  template. Exported variable template. Exported variable template. Exported
+  variable template. Exported variable template.
+</template>;
+(oh, no) => {};
+"
+`;
+
+exports[`ambiguous > config > default > (oh, no) => {} > with semi, without newline > it formats ../cases/gts/exported-mod-var-with-as.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
+
+export interface Signature {
+  Element: HTMLElement;
+  Args: {};
+  Yields: [];
+}
+
+export const Exported = <template>
+  Exported variable template. Exported variable template. Exported variable
+  template. Exported variable template. Exported variable template. Exported
+  variable template. Exported variable template.
+</template> as TemplateOnlyComponent<Signature>;
+(oh, no) => {};
+"
+`;
+
+exports[`ambiguous > config > default > (oh, no) => {} > with semi, without newline > it formats ../cases/gts/js-only.gts 1`] = `
+"const num: number = 1;
+(oh, no) => {};
+"
+`;
+
+exports[`ambiguous > config > default > (oh, no) => {} > with semi, without newline > it formats ../cases/gts/mod-var.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
+
+export interface Signature {
+  Element: HTMLElement;
+  Args: {};
+  Yields: [];
+}
+
+const Private: TemplateOnlyComponent<Signature> = <template>
+  Private variable template. Private variable template. Private variable
+  template. Private variable template. Private variable template. Private
+  variable template. Private variable template.
+</template>;
+(oh, no) => {};
+"
+`;
+
+exports[`ambiguous > config > default > (oh, no) => {} > with semi, without newline > it formats ../cases/gts/mod-var-with-as.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
+
+export interface Signature {
+  Element: HTMLElement;
+  Args: {};
+  Yields: [];
+}
+
+const Private = <template>
+  Private variable template. Private variable template. Private variable
+  template. Private variable template. Private variable template. Private
+  variable template. Private variable template.
+</template> as TemplateOnlyComponent<Signature>;
+(oh, no) => {};
+"
+`;
+
+exports[`ambiguous > config > default > (oh, no) => {} > with semi, without newline > it formats ../cases/gts/multiple-declarations.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
+
+export interface Signature {
+  Element: HTMLElement;
+  Args: {};
+  Yields: [];
+}
+
+const ModVar1: TemplateOnlyComponent<Signature> = <template>
+    <h1>
+      Module variable template. Module variable template. Module variable
+      template. Module variable template. Module variable template. Module
+      variable template. Module variable template. Module variable template.
+    </h1>
+  </template>,
+  ModVar2: TemplateOnlyComponent<Signature> = <template>
+    Second module variable template.
+  </template>,
+  num = 1;
+(oh, no) => {};
+
+const bool: boolean = false,
+  ModVar3: TemplateOnlyComponent<Signature> = <template>
+    <h1>
+      Module variable template. Module variable template. Module variable
+      template. Module variable template. Module variable template. Module
+      variable template. Module variable template. Module variable template.
+    </h1>
+  </template>,
+  ModVar4: TemplateOnlyComponent<Signature> = <template>
+    Second module variable template.
+  </template>;
+(oh, no) => {};
+"
+`;
+
+exports[`ambiguous > config > default > (oh, no) => {} > with semi, without newline > it formats ../cases/gts/multiple-declarations-with-as.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
+
+export interface Signature {
+  Element: HTMLElement;
+  Args: {};
+  Yields: [];
+}
+
+const ModVar1 = <template>
+    <h1>
+      Module variable template. Module variable template. Module variable
+      template. Module variable template. Module variable template. Module
+      variable template. Module variable template. Module variable template.
+    </h1>
+  </template> as TemplateOnlyComponent<Signature>,
+  ModVar2 = <template>
+    Second module variable template.
+  </template> as TemplateOnlyComponent<Signature>,
+  num = 1;
+(oh, no) => {};
+
+const bool: boolean = false,
+  ModVar3 = <template>
+    <h1>
+      Module variable template. Module variable template. Module variable
+      template. Module variable template. Module variable template. Module
+      variable template. Module variable template. Module variable template.
+    </h1>
+  </template> as TemplateOnlyComponent<Signature>,
+  ModVar4 = <template>
+    Second module variable template.
+  </template> as TemplateOnlyComponent<Signature>;
+(oh, no) => {};
+"
+`;
+
+exports[`ambiguous > config > default > (oh, no) => {} > with semi, without newline > it formats ../cases/gts/simple.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
+
+export interface Signature {
+  Element: HTMLElement;
+  Args: {};
+  Yields: [];
+}
+
+<template>
+  what
+</template> as TemplateOnlyComponent<Signature>;
+(oh, no) => {};
+"
+`;
+
 exports[`ambiguous > config > default > (oh, no) => {} > without semi, with newline > it formats ../cases/gts/default-export.gts 1`] = `
 "import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
 
@@ -1163,6 +1423,266 @@ export interface Signature {
 `;
 
 exports[`ambiguous > config > default > (oops) => {} > with semi, with newline > it formats ../cases/gts/simple.gts 2`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
+
+export interface Signature {
+  Element: HTMLElement;
+  Args: {};
+  Yields: [];
+}
+
+<template>
+  what
+</template> as TemplateOnlyComponent<Signature>;
+(oops) => {};
+"
+`;
+
+exports[`ambiguous > config > default > (oops) => {} > with semi, without newline > it formats ../cases/gjs/default-export.gjs 1`] = `
+"<template>
+  Explicit default export module top level component. Explicit default export
+  module top level component. Explicit default export module top level
+  component. Explicit default export module top level component. Explicit
+  default export module top level component.
+</template>;
+(oops) => {};
+"
+`;
+
+exports[`ambiguous > config > default > (oops) => {} > with semi, without newline > it formats ../cases/gjs/exported-mod-var.gjs 1`] = `
+"export const Exported = <template>
+  Exported variable template. Exported variable template. Exported variable
+  template. Exported variable template. Exported variable template. Exported
+  variable template. Exported variable template.
+</template>;
+(oops) => {};
+"
+`;
+
+exports[`ambiguous > config > default > (oops) => {} > with semi, without newline > it formats ../cases/gjs/js-only.gjs 1`] = `
+"const num = 1;
+(oops) => {};
+"
+`;
+
+exports[`ambiguous > config > default > (oops) => {} > with semi, without newline > it formats ../cases/gjs/mod-var.gjs 1`] = `
+"const Private = <template>
+  Private variable template. Private variable template. Private variable
+  template. Private variable template. Private variable template. Private
+  variable template. Private variable template.
+</template>;
+(oops) => {};
+
+const What = <template>Hi</template>;
+(oops) => {};
+"
+`;
+
+exports[`ambiguous > config > default > (oops) => {} > with semi, without newline > it formats ../cases/gjs/multiple-declarations.gjs 1`] = `
+"const ModVar1 = <template>
+    <h1>
+      Module variable template. Module variable template. Module variable
+      template. Module variable template. Module variable template. Module
+      variable template. Module variable template. Module variable template.
+    </h1>
+  </template>,
+  ModVar2 = <template>Second module variable template.</template>,
+  num = 1;
+(oops) => {};
+
+const bool = false,
+  ModVar3 = <template>
+    <h1>
+      Module variable template. Module variable template. Module variable
+      template. Module variable template. Module variable template. Module
+      variable template. Module variable template. Module variable template.
+    </h1>
+  </template>,
+  ModVar4 = <template>Second module variable template.</template>;
+(oops) => {};
+"
+`;
+
+exports[`ambiguous > config > default > (oops) => {} > with semi, without newline > it formats ../cases/gjs/simple.gjs 1`] = `
+"<template>
+  what
+</template>;
+(oops) => {};
+"
+`;
+
+exports[`ambiguous > config > default > (oops) => {} > with semi, without newline > it formats ../cases/gts/default-export.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
+
+export interface Signature {
+  Element: HTMLElement;
+  Args: {};
+  Yields: [];
+}
+
+<template>
+  Explicit default export module top level component. Explicit default export
+  module top level component. Explicit default export module top level
+  component. Explicit default export module top level component. Explicit
+  default export module top level component.
+</template> as TemplateOnlyComponent<Signature>;
+(oops) => {};
+"
+`;
+
+exports[`ambiguous > config > default > (oops) => {} > with semi, without newline > it formats ../cases/gts/exported-mod-var.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
+
+export interface Signature {
+  Element: HTMLElement;
+  Args: {};
+  Yields: [];
+}
+
+export const Exported: TemplateOnlyComponent<Signature> = <template>
+  Exported variable template. Exported variable template. Exported variable
+  template. Exported variable template. Exported variable template. Exported
+  variable template. Exported variable template.
+</template>;
+(oops) => {};
+"
+`;
+
+exports[`ambiguous > config > default > (oops) => {} > with semi, without newline > it formats ../cases/gts/exported-mod-var-with-as.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
+
+export interface Signature {
+  Element: HTMLElement;
+  Args: {};
+  Yields: [];
+}
+
+export const Exported = <template>
+  Exported variable template. Exported variable template. Exported variable
+  template. Exported variable template. Exported variable template. Exported
+  variable template. Exported variable template.
+</template> as TemplateOnlyComponent<Signature>;
+(oops) => {};
+"
+`;
+
+exports[`ambiguous > config > default > (oops) => {} > with semi, without newline > it formats ../cases/gts/js-only.gts 1`] = `
+"const num: number = 1;
+(oops) => {};
+"
+`;
+
+exports[`ambiguous > config > default > (oops) => {} > with semi, without newline > it formats ../cases/gts/mod-var.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
+
+export interface Signature {
+  Element: HTMLElement;
+  Args: {};
+  Yields: [];
+}
+
+const Private: TemplateOnlyComponent<Signature> = <template>
+  Private variable template. Private variable template. Private variable
+  template. Private variable template. Private variable template. Private
+  variable template. Private variable template.
+</template>;
+(oops) => {};
+"
+`;
+
+exports[`ambiguous > config > default > (oops) => {} > with semi, without newline > it formats ../cases/gts/mod-var-with-as.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
+
+export interface Signature {
+  Element: HTMLElement;
+  Args: {};
+  Yields: [];
+}
+
+const Private = <template>
+  Private variable template. Private variable template. Private variable
+  template. Private variable template. Private variable template. Private
+  variable template. Private variable template.
+</template> as TemplateOnlyComponent<Signature>;
+(oops) => {};
+"
+`;
+
+exports[`ambiguous > config > default > (oops) => {} > with semi, without newline > it formats ../cases/gts/multiple-declarations.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
+
+export interface Signature {
+  Element: HTMLElement;
+  Args: {};
+  Yields: [];
+}
+
+const ModVar1: TemplateOnlyComponent<Signature> = <template>
+    <h1>
+      Module variable template. Module variable template. Module variable
+      template. Module variable template. Module variable template. Module
+      variable template. Module variable template. Module variable template.
+    </h1>
+  </template>,
+  ModVar2: TemplateOnlyComponent<Signature> = <template>
+    Second module variable template.
+  </template>,
+  num = 1;
+(oops) => {};
+
+const bool: boolean = false,
+  ModVar3: TemplateOnlyComponent<Signature> = <template>
+    <h1>
+      Module variable template. Module variable template. Module variable
+      template. Module variable template. Module variable template. Module
+      variable template. Module variable template. Module variable template.
+    </h1>
+  </template>,
+  ModVar4: TemplateOnlyComponent<Signature> = <template>
+    Second module variable template.
+  </template>;
+(oops) => {};
+"
+`;
+
+exports[`ambiguous > config > default > (oops) => {} > with semi, without newline > it formats ../cases/gts/multiple-declarations-with-as.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
+
+export interface Signature {
+  Element: HTMLElement;
+  Args: {};
+  Yields: [];
+}
+
+const ModVar1 = <template>
+    <h1>
+      Module variable template. Module variable template. Module variable
+      template. Module variable template. Module variable template. Module
+      variable template. Module variable template. Module variable template.
+    </h1>
+  </template> as TemplateOnlyComponent<Signature>,
+  ModVar2 = <template>
+    Second module variable template.
+  </template> as TemplateOnlyComponent<Signature>,
+  num = 1;
+(oops) => {};
+
+const bool: boolean = false,
+  ModVar3 = <template>
+    <h1>
+      Module variable template. Module variable template. Module variable
+      template. Module variable template. Module variable template. Module
+      variable template. Module variable template. Module variable template.
+    </h1>
+  </template> as TemplateOnlyComponent<Signature>,
+  ModVar4 = <template>
+    Second module variable template.
+  </template> as TemplateOnlyComponent<Signature>;
+(oops) => {};
+"
+`;
+
+exports[`ambiguous > config > default > (oops) => {} > with semi, without newline > it formats ../cases/gts/simple.gts 1`] = `
 "import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
 
 export interface Signature {
@@ -1836,6 +2356,266 @@ export interface Signature {
 "
 `;
 
+exports[`ambiguous > config > default > +"oops" > with semi, without newline > it formats ../cases/gjs/default-export.gjs 1`] = `
+"<template>
+  Explicit default export module top level component. Explicit default export
+  module top level component. Explicit default export module top level
+  component. Explicit default export module top level component. Explicit
+  default export module top level component.
+</template>;
++\\"oops\\";
+"
+`;
+
+exports[`ambiguous > config > default > +"oops" > with semi, without newline > it formats ../cases/gjs/exported-mod-var.gjs 1`] = `
+"export const Exported = <template>
+  Exported variable template. Exported variable template. Exported variable
+  template. Exported variable template. Exported variable template. Exported
+  variable template. Exported variable template.
+</template>;
++\\"oops\\";
+"
+`;
+
+exports[`ambiguous > config > default > +"oops" > with semi, without newline > it formats ../cases/gjs/js-only.gjs 1`] = `
+"const num = 1;
++\\"oops\\";
+"
+`;
+
+exports[`ambiguous > config > default > +"oops" > with semi, without newline > it formats ../cases/gjs/mod-var.gjs 1`] = `
+"const Private = <template>
+  Private variable template. Private variable template. Private variable
+  template. Private variable template. Private variable template. Private
+  variable template. Private variable template.
+</template>;
++\\"oops\\";
+
+const What = <template>Hi</template>;
++\\"oops\\";
+"
+`;
+
+exports[`ambiguous > config > default > +"oops" > with semi, without newline > it formats ../cases/gjs/multiple-declarations.gjs 1`] = `
+"const ModVar1 = <template>
+    <h1>
+      Module variable template. Module variable template. Module variable
+      template. Module variable template. Module variable template. Module
+      variable template. Module variable template. Module variable template.
+    </h1>
+  </template>,
+  ModVar2 = <template>Second module variable template.</template>,
+  num = 1;
++\\"oops\\";
+
+const bool = false,
+  ModVar3 = <template>
+    <h1>
+      Module variable template. Module variable template. Module variable
+      template. Module variable template. Module variable template. Module
+      variable template. Module variable template. Module variable template.
+    </h1>
+  </template>,
+  ModVar4 = <template>Second module variable template.</template>;
++\\"oops\\";
+"
+`;
+
+exports[`ambiguous > config > default > +"oops" > with semi, without newline > it formats ../cases/gjs/simple.gjs 1`] = `
+"<template>
+  what
+</template>;
++\\"oops\\";
+"
+`;
+
+exports[`ambiguous > config > default > +"oops" > with semi, without newline > it formats ../cases/gts/default-export.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
+
+export interface Signature {
+  Element: HTMLElement;
+  Args: {};
+  Yields: [];
+}
+
+<template>
+  Explicit default export module top level component. Explicit default export
+  module top level component. Explicit default export module top level
+  component. Explicit default export module top level component. Explicit
+  default export module top level component.
+</template> as TemplateOnlyComponent<Signature>;
++\\"oops\\";
+"
+`;
+
+exports[`ambiguous > config > default > +"oops" > with semi, without newline > it formats ../cases/gts/exported-mod-var.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
+
+export interface Signature {
+  Element: HTMLElement;
+  Args: {};
+  Yields: [];
+}
+
+export const Exported: TemplateOnlyComponent<Signature> = <template>
+  Exported variable template. Exported variable template. Exported variable
+  template. Exported variable template. Exported variable template. Exported
+  variable template. Exported variable template.
+</template>;
++\\"oops\\";
+"
+`;
+
+exports[`ambiguous > config > default > +"oops" > with semi, without newline > it formats ../cases/gts/exported-mod-var-with-as.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
+
+export interface Signature {
+  Element: HTMLElement;
+  Args: {};
+  Yields: [];
+}
+
+export const Exported = <template>
+  Exported variable template. Exported variable template. Exported variable
+  template. Exported variable template. Exported variable template. Exported
+  variable template. Exported variable template.
+</template> as TemplateOnlyComponent<Signature>;
++\\"oops\\";
+"
+`;
+
+exports[`ambiguous > config > default > +"oops" > with semi, without newline > it formats ../cases/gts/js-only.gts 1`] = `
+"const num: number = 1;
++\\"oops\\";
+"
+`;
+
+exports[`ambiguous > config > default > +"oops" > with semi, without newline > it formats ../cases/gts/mod-var.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
+
+export interface Signature {
+  Element: HTMLElement;
+  Args: {};
+  Yields: [];
+}
+
+const Private: TemplateOnlyComponent<Signature> = <template>
+  Private variable template. Private variable template. Private variable
+  template. Private variable template. Private variable template. Private
+  variable template. Private variable template.
+</template>;
++\\"oops\\";
+"
+`;
+
+exports[`ambiguous > config > default > +"oops" > with semi, without newline > it formats ../cases/gts/mod-var-with-as.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
+
+export interface Signature {
+  Element: HTMLElement;
+  Args: {};
+  Yields: [];
+}
+
+const Private = <template>
+  Private variable template. Private variable template. Private variable
+  template. Private variable template. Private variable template. Private
+  variable template. Private variable template.
+</template> as TemplateOnlyComponent<Signature>;
++\\"oops\\";
+"
+`;
+
+exports[`ambiguous > config > default > +"oops" > with semi, without newline > it formats ../cases/gts/multiple-declarations.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
+
+export interface Signature {
+  Element: HTMLElement;
+  Args: {};
+  Yields: [];
+}
+
+const ModVar1: TemplateOnlyComponent<Signature> = <template>
+    <h1>
+      Module variable template. Module variable template. Module variable
+      template. Module variable template. Module variable template. Module
+      variable template. Module variable template. Module variable template.
+    </h1>
+  </template>,
+  ModVar2: TemplateOnlyComponent<Signature> = <template>
+    Second module variable template.
+  </template>,
+  num = 1;
++\\"oops\\";
+
+const bool: boolean = false,
+  ModVar3: TemplateOnlyComponent<Signature> = <template>
+    <h1>
+      Module variable template. Module variable template. Module variable
+      template. Module variable template. Module variable template. Module
+      variable template. Module variable template. Module variable template.
+    </h1>
+  </template>,
+  ModVar4: TemplateOnlyComponent<Signature> = <template>
+    Second module variable template.
+  </template>;
++\\"oops\\";
+"
+`;
+
+exports[`ambiguous > config > default > +"oops" > with semi, without newline > it formats ../cases/gts/multiple-declarations-with-as.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
+
+export interface Signature {
+  Element: HTMLElement;
+  Args: {};
+  Yields: [];
+}
+
+const ModVar1 = <template>
+    <h1>
+      Module variable template. Module variable template. Module variable
+      template. Module variable template. Module variable template. Module
+      variable template. Module variable template. Module variable template.
+    </h1>
+  </template> as TemplateOnlyComponent<Signature>,
+  ModVar2 = <template>
+    Second module variable template.
+  </template> as TemplateOnlyComponent<Signature>,
+  num = 1;
++\\"oops\\";
+
+const bool: boolean = false,
+  ModVar3 = <template>
+    <h1>
+      Module variable template. Module variable template. Module variable
+      template. Module variable template. Module variable template. Module
+      variable template. Module variable template. Module variable template.
+    </h1>
+  </template> as TemplateOnlyComponent<Signature>,
+  ModVar4 = <template>
+    Second module variable template.
+  </template> as TemplateOnlyComponent<Signature>;
++\\"oops\\";
+"
+`;
+
+exports[`ambiguous > config > default > +"oops" > with semi, without newline > it formats ../cases/gts/simple.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
+
+export interface Signature {
+  Element: HTMLElement;
+  Args: {};
+  Yields: [];
+}
+
+<template>
+  what
+</template> as TemplateOnlyComponent<Signature>;
++\\"oops\\";
+"
+`;
+
 exports[`ambiguous > config > default > +"oops" > without semi, with newline > it formats ../cases/gjs/js-only.gjs 1`] = `
 "const num = 1 + \\"oops\\";
 "
@@ -2361,6 +3141,266 @@ export interface Signature {
 `;
 
 exports[`ambiguous > config > default > /oops/ > with semi, with newline > it formats ../cases/gts/simple.gts 2`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
+
+export interface Signature {
+  Element: HTMLElement;
+  Args: {};
+  Yields: [];
+}
+
+<template>
+  what
+</template> as TemplateOnlyComponent<Signature>;
+/oops/;
+"
+`;
+
+exports[`ambiguous > config > default > /oops/ > with semi, without newline > it formats ../cases/gjs/default-export.gjs 1`] = `
+"<template>
+  Explicit default export module top level component. Explicit default export
+  module top level component. Explicit default export module top level
+  component. Explicit default export module top level component. Explicit
+  default export module top level component.
+</template>;
+/oops/;
+"
+`;
+
+exports[`ambiguous > config > default > /oops/ > with semi, without newline > it formats ../cases/gjs/exported-mod-var.gjs 1`] = `
+"export const Exported = <template>
+  Exported variable template. Exported variable template. Exported variable
+  template. Exported variable template. Exported variable template. Exported
+  variable template. Exported variable template.
+</template>;
+/oops/;
+"
+`;
+
+exports[`ambiguous > config > default > /oops/ > with semi, without newline > it formats ../cases/gjs/js-only.gjs 1`] = `
+"const num = 1;
+/oops/;
+"
+`;
+
+exports[`ambiguous > config > default > /oops/ > with semi, without newline > it formats ../cases/gjs/mod-var.gjs 1`] = `
+"const Private = <template>
+  Private variable template. Private variable template. Private variable
+  template. Private variable template. Private variable template. Private
+  variable template. Private variable template.
+</template>;
+/oops/;
+
+const What = <template>Hi</template>;
+/oops/;
+"
+`;
+
+exports[`ambiguous > config > default > /oops/ > with semi, without newline > it formats ../cases/gjs/multiple-declarations.gjs 1`] = `
+"const ModVar1 = <template>
+    <h1>
+      Module variable template. Module variable template. Module variable
+      template. Module variable template. Module variable template. Module
+      variable template. Module variable template. Module variable template.
+    </h1>
+  </template>,
+  ModVar2 = <template>Second module variable template.</template>,
+  num = 1;
+/oops/;
+
+const bool = false,
+  ModVar3 = <template>
+    <h1>
+      Module variable template. Module variable template. Module variable
+      template. Module variable template. Module variable template. Module
+      variable template. Module variable template. Module variable template.
+    </h1>
+  </template>,
+  ModVar4 = <template>Second module variable template.</template>;
+/oops/;
+"
+`;
+
+exports[`ambiguous > config > default > /oops/ > with semi, without newline > it formats ../cases/gjs/simple.gjs 1`] = `
+"<template>
+  what
+</template>;
+/oops/;
+"
+`;
+
+exports[`ambiguous > config > default > /oops/ > with semi, without newline > it formats ../cases/gts/default-export.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
+
+export interface Signature {
+  Element: HTMLElement;
+  Args: {};
+  Yields: [];
+}
+
+<template>
+  Explicit default export module top level component. Explicit default export
+  module top level component. Explicit default export module top level
+  component. Explicit default export module top level component. Explicit
+  default export module top level component.
+</template> as TemplateOnlyComponent<Signature>;
+/oops/;
+"
+`;
+
+exports[`ambiguous > config > default > /oops/ > with semi, without newline > it formats ../cases/gts/exported-mod-var.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
+
+export interface Signature {
+  Element: HTMLElement;
+  Args: {};
+  Yields: [];
+}
+
+export const Exported: TemplateOnlyComponent<Signature> = <template>
+  Exported variable template. Exported variable template. Exported variable
+  template. Exported variable template. Exported variable template. Exported
+  variable template. Exported variable template.
+</template>;
+/oops/;
+"
+`;
+
+exports[`ambiguous > config > default > /oops/ > with semi, without newline > it formats ../cases/gts/exported-mod-var-with-as.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
+
+export interface Signature {
+  Element: HTMLElement;
+  Args: {};
+  Yields: [];
+}
+
+export const Exported = <template>
+  Exported variable template. Exported variable template. Exported variable
+  template. Exported variable template. Exported variable template. Exported
+  variable template. Exported variable template.
+</template> as TemplateOnlyComponent<Signature>;
+/oops/;
+"
+`;
+
+exports[`ambiguous > config > default > /oops/ > with semi, without newline > it formats ../cases/gts/js-only.gts 1`] = `
+"const num: number = 1;
+/oops/;
+"
+`;
+
+exports[`ambiguous > config > default > /oops/ > with semi, without newline > it formats ../cases/gts/mod-var.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
+
+export interface Signature {
+  Element: HTMLElement;
+  Args: {};
+  Yields: [];
+}
+
+const Private: TemplateOnlyComponent<Signature> = <template>
+  Private variable template. Private variable template. Private variable
+  template. Private variable template. Private variable template. Private
+  variable template. Private variable template.
+</template>;
+/oops/;
+"
+`;
+
+exports[`ambiguous > config > default > /oops/ > with semi, without newline > it formats ../cases/gts/mod-var-with-as.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
+
+export interface Signature {
+  Element: HTMLElement;
+  Args: {};
+  Yields: [];
+}
+
+const Private = <template>
+  Private variable template. Private variable template. Private variable
+  template. Private variable template. Private variable template. Private
+  variable template. Private variable template.
+</template> as TemplateOnlyComponent<Signature>;
+/oops/;
+"
+`;
+
+exports[`ambiguous > config > default > /oops/ > with semi, without newline > it formats ../cases/gts/multiple-declarations.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
+
+export interface Signature {
+  Element: HTMLElement;
+  Args: {};
+  Yields: [];
+}
+
+const ModVar1: TemplateOnlyComponent<Signature> = <template>
+    <h1>
+      Module variable template. Module variable template. Module variable
+      template. Module variable template. Module variable template. Module
+      variable template. Module variable template. Module variable template.
+    </h1>
+  </template>,
+  ModVar2: TemplateOnlyComponent<Signature> = <template>
+    Second module variable template.
+  </template>,
+  num = 1;
+/oops/;
+
+const bool: boolean = false,
+  ModVar3: TemplateOnlyComponent<Signature> = <template>
+    <h1>
+      Module variable template. Module variable template. Module variable
+      template. Module variable template. Module variable template. Module
+      variable template. Module variable template. Module variable template.
+    </h1>
+  </template>,
+  ModVar4: TemplateOnlyComponent<Signature> = <template>
+    Second module variable template.
+  </template>;
+/oops/;
+"
+`;
+
+exports[`ambiguous > config > default > /oops/ > with semi, without newline > it formats ../cases/gts/multiple-declarations-with-as.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
+
+export interface Signature {
+  Element: HTMLElement;
+  Args: {};
+  Yields: [];
+}
+
+const ModVar1 = <template>
+    <h1>
+      Module variable template. Module variable template. Module variable
+      template. Module variable template. Module variable template. Module
+      variable template. Module variable template. Module variable template.
+    </h1>
+  </template> as TemplateOnlyComponent<Signature>,
+  ModVar2 = <template>
+    Second module variable template.
+  </template> as TemplateOnlyComponent<Signature>,
+  num = 1;
+/oops/;
+
+const bool: boolean = false,
+  ModVar3 = <template>
+    <h1>
+      Module variable template. Module variable template. Module variable
+      template. Module variable template. Module variable template. Module
+      variable template. Module variable template. Module variable template.
+    </h1>
+  </template> as TemplateOnlyComponent<Signature>,
+  ModVar4 = <template>
+    Second module variable template.
+  </template> as TemplateOnlyComponent<Signature>;
+/oops/;
+"
+`;
+
+exports[`ambiguous > config > default > /oops/ > with semi, without newline > it formats ../cases/gts/simple.gts 1`] = `
 "import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
 
 export interface Signature {
@@ -3014,6 +4054,299 @@ export interface Signature {
 `;
 
 exports[`ambiguous > config > default > <template>oops</template> > with semi, with newline > it formats ../cases/gts/simple.gts 2`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
+
+export interface Signature {
+  Element: HTMLElement;
+  Args: {};
+  Yields: [];
+}
+
+<template>
+  what
+</template> as TemplateOnlyComponent<Signature>
+<template>
+  oops
+</template>
+"
+`;
+
+exports[`ambiguous > config > default > <template>oops</template> > with semi, without newline > it formats ../cases/gjs/default-export.gjs 1`] = `
+"<template>
+  Explicit default export module top level component. Explicit default export
+  module top level component. Explicit default export module top level
+  component. Explicit default export module top level component. Explicit
+  default export module top level component.
+</template>
+<template>
+  oops
+</template>
+"
+`;
+
+exports[`ambiguous > config > default > <template>oops</template> > with semi, without newline > it formats ../cases/gjs/exported-mod-var.gjs 1`] = `
+"export const Exported = <template>
+  Exported variable template. Exported variable template. Exported variable
+  template. Exported variable template. Exported variable template. Exported
+  variable template. Exported variable template.
+</template>;
+<template>
+  oops
+</template>
+"
+`;
+
+exports[`ambiguous > config > default > <template>oops</template> > with semi, without newline > it formats ../cases/gjs/js-only.gjs 1`] = `
+"const num = 1;
+<template>
+  oops
+</template>
+"
+`;
+
+exports[`ambiguous > config > default > <template>oops</template> > with semi, without newline > it formats ../cases/gjs/mod-var.gjs 1`] = `
+"const Private = <template>
+  Private variable template. Private variable template. Private variable
+  template. Private variable template. Private variable template. Private
+  variable template. Private variable template.
+</template>;
+<template>
+  oops
+</template>
+const What = <template>Hi</template>;
+<template>oops</template>
+"
+`;
+
+exports[`ambiguous > config > default > <template>oops</template> > with semi, without newline > it formats ../cases/gjs/multiple-declarations.gjs 1`] = `
+"const ModVar1 = <template>
+    <h1>
+      Module variable template. Module variable template. Module variable
+      template. Module variable template. Module variable template. Module
+      variable template. Module variable template. Module variable template.
+    </h1>
+  </template>,
+  ModVar2 = <template>Second module variable template.</template>,
+  num = 1;
+<template>
+  oops
+</template>
+const bool = false,
+  ModVar3 = <template>
+    <h1>
+      Module variable template. Module variable template. Module variable
+      template. Module variable template. Module variable template. Module
+      variable template. Module variable template. Module variable template.
+    </h1>
+  </template>,
+  ModVar4 = <template>Second module variable template.</template>;
+<template>
+  oops
+</template>
+"
+`;
+
+exports[`ambiguous > config > default > <template>oops</template> > with semi, without newline > it formats ../cases/gjs/simple.gjs 1`] = `
+"<template>
+  what
+</template>
+<template>
+  oops
+</template>
+"
+`;
+
+exports[`ambiguous > config > default > <template>oops</template> > with semi, without newline > it formats ../cases/gts/default-export.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
+
+export interface Signature {
+  Element: HTMLElement;
+  Args: {};
+  Yields: [];
+}
+
+<template>
+  Explicit default export module top level component. Explicit default export
+  module top level component. Explicit default export module top level
+  component. Explicit default export module top level component. Explicit
+  default export module top level component.
+</template> as TemplateOnlyComponent<Signature>
+<template>
+  oops
+</template>
+"
+`;
+
+exports[`ambiguous > config > default > <template>oops</template> > with semi, without newline > it formats ../cases/gts/exported-mod-var.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
+
+export interface Signature {
+  Element: HTMLElement;
+  Args: {};
+  Yields: [];
+}
+
+export const Exported: TemplateOnlyComponent<Signature> = <template>
+  Exported variable template. Exported variable template. Exported variable
+  template. Exported variable template. Exported variable template. Exported
+  variable template. Exported variable template.
+</template>;
+<template>
+  oops
+</template>
+"
+`;
+
+exports[`ambiguous > config > default > <template>oops</template> > with semi, without newline > it formats ../cases/gts/exported-mod-var-with-as.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
+
+export interface Signature {
+  Element: HTMLElement;
+  Args: {};
+  Yields: [];
+}
+
+export const Exported = <template>
+  Exported variable template. Exported variable template. Exported variable
+  template. Exported variable template. Exported variable template. Exported
+  variable template. Exported variable template.
+</template> as TemplateOnlyComponent<Signature>;
+<template>
+  oops
+</template>
+"
+`;
+
+exports[`ambiguous > config > default > <template>oops</template> > with semi, without newline > it formats ../cases/gts/js-only.gts 1`] = `
+"const num: number = 1;
+<template>
+  oops
+</template>
+"
+`;
+
+exports[`ambiguous > config > default > <template>oops</template> > with semi, without newline > it formats ../cases/gts/mod-var.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
+
+export interface Signature {
+  Element: HTMLElement;
+  Args: {};
+  Yields: [];
+}
+
+const Private: TemplateOnlyComponent<Signature> = <template>
+  Private variable template. Private variable template. Private variable
+  template. Private variable template. Private variable template. Private
+  variable template. Private variable template.
+</template>;
+<template>
+  oops
+</template>
+"
+`;
+
+exports[`ambiguous > config > default > <template>oops</template> > with semi, without newline > it formats ../cases/gts/mod-var-with-as.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
+
+export interface Signature {
+  Element: HTMLElement;
+  Args: {};
+  Yields: [];
+}
+
+const Private = <template>
+  Private variable template. Private variable template. Private variable
+  template. Private variable template. Private variable template. Private
+  variable template. Private variable template.
+</template> as TemplateOnlyComponent<Signature>;
+<template>
+  oops
+</template>
+"
+`;
+
+exports[`ambiguous > config > default > <template>oops</template> > with semi, without newline > it formats ../cases/gts/multiple-declarations.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
+
+export interface Signature {
+  Element: HTMLElement;
+  Args: {};
+  Yields: [];
+}
+
+const ModVar1: TemplateOnlyComponent<Signature> = <template>
+    <h1>
+      Module variable template. Module variable template. Module variable
+      template. Module variable template. Module variable template. Module
+      variable template. Module variable template. Module variable template.
+    </h1>
+  </template>,
+  ModVar2: TemplateOnlyComponent<Signature> = <template>
+    Second module variable template.
+  </template>,
+  num = 1;
+<template>
+  oops
+</template>
+const bool: boolean = false,
+  ModVar3: TemplateOnlyComponent<Signature> = <template>
+    <h1>
+      Module variable template. Module variable template. Module variable
+      template. Module variable template. Module variable template. Module
+      variable template. Module variable template. Module variable template.
+    </h1>
+  </template>,
+  ModVar4: TemplateOnlyComponent<Signature> = <template>
+    Second module variable template.
+  </template>;
+<template>
+  oops
+</template>
+"
+`;
+
+exports[`ambiguous > config > default > <template>oops</template> > with semi, without newline > it formats ../cases/gts/multiple-declarations-with-as.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
+
+export interface Signature {
+  Element: HTMLElement;
+  Args: {};
+  Yields: [];
+}
+
+const ModVar1 = <template>
+    <h1>
+      Module variable template. Module variable template. Module variable
+      template. Module variable template. Module variable template. Module
+      variable template. Module variable template. Module variable template.
+    </h1>
+  </template> as TemplateOnlyComponent<Signature>,
+  ModVar2 = <template>
+    Second module variable template.
+  </template> as TemplateOnlyComponent<Signature>,
+  num = 1;
+<template>
+  oops
+</template>
+
+const bool: boolean = false,
+  ModVar3 = <template>
+    <h1>
+      Module variable template. Module variable template. Module variable
+      template. Module variable template. Module variable template. Module
+      variable template. Module variable template. Module variable template.
+    </h1>
+  </template> as TemplateOnlyComponent<Signature>,
+  ModVar4 = <template>
+    Second module variable template.
+  </template> as TemplateOnlyComponent<Signature>;
+<template>
+  oops
+</template>
+"
+`;
+
+exports[`ambiguous > config > default > <template>oops</template> > with semi, without newline > it formats ../cases/gts/simple.gts 1`] = `
 "import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
 
 export interface Signature {
@@ -4255,6 +5588,324 @@ export interface Signature {
 "
 `;
 
+exports[`ambiguous > config > default > ["oops"] > with semi, without newline > it formats ../cases/gjs/component-class.gjs 1`] = `
+"import Component from \\"@glimmer/component\\";
+
+/** It's a component */
+class MyComponent extends Component {
+  <template>
+    <h1>
+      Class top level template. Class top level template. Class top level
+      template. Class top level template. Class top level template.
+    </h1>
+  </template>
+  [\\"oops\\"];
+}
+"
+`;
+
+exports[`ambiguous > config > default > ["oops"] > with semi, without newline > it formats ../cases/gjs/component-class-with-content-before-template.gjs 1`] = `
+"import Component from \\"@glimmer/component\\";
+
+/** It's a component */
+class MyComponent extends Component {
+  get whatever() {}
+
+  <template>
+    <h1>
+      Class top level template. Class top level template. Class top level
+      template. Class top level template. Class top level template.
+    </h1>
+  </template>
+  [\\"oops\\"];
+}
+"
+`;
+
+exports[`ambiguous > config > default > ["oops"] > with semi, without newline > it formats ../cases/gjs/default-export.gjs 1`] = `
+"<template>
+  Explicit default export module top level component. Explicit default export
+  module top level component. Explicit default export module top level
+  component. Explicit default export module top level component. Explicit
+  default export module top level component.
+</template>;
+[\\"oops\\"];
+"
+`;
+
+exports[`ambiguous > config > default > ["oops"] > with semi, without newline > it formats ../cases/gjs/exported-mod-var.gjs 1`] = `
+"export const Exported = <template>
+  Exported variable template. Exported variable template. Exported variable
+  template. Exported variable template. Exported variable template. Exported
+  variable template. Exported variable template.
+</template>;
+[\\"oops\\"];
+"
+`;
+
+exports[`ambiguous > config > default > ["oops"] > with semi, without newline > it formats ../cases/gjs/js-only.gjs 1`] = `
+"const num = 1;
+[\\"oops\\"];
+"
+`;
+
+exports[`ambiguous > config > default > ["oops"] > with semi, without newline > it formats ../cases/gjs/mod-var.gjs 1`] = `
+"const Private = <template>
+  Private variable template. Private variable template. Private variable
+  template. Private variable template. Private variable template. Private
+  variable template. Private variable template.
+</template>;
+[\\"oops\\"];
+
+const What = <template>Hi</template>;
+[\\"oops\\"];
+"
+`;
+
+exports[`ambiguous > config > default > ["oops"] > with semi, without newline > it formats ../cases/gjs/multiple-declarations.gjs 1`] = `
+"const ModVar1 = <template>
+    <h1>
+      Module variable template. Module variable template. Module variable
+      template. Module variable template. Module variable template. Module
+      variable template. Module variable template. Module variable template.
+    </h1>
+  </template>,
+  ModVar2 = <template>Second module variable template.</template>,
+  num = 1;
+[\\"oops\\"];
+
+const bool = false,
+  ModVar3 = <template>
+    <h1>
+      Module variable template. Module variable template. Module variable
+      template. Module variable template. Module variable template. Module
+      variable template. Module variable template. Module variable template.
+    </h1>
+  </template>,
+  ModVar4 = <template>Second module variable template.</template>;
+[\\"oops\\"];
+"
+`;
+
+exports[`ambiguous > config > default > ["oops"] > with semi, without newline > it formats ../cases/gjs/simple.gjs 1`] = `
+"<template>
+  what
+</template>;
+[\\"oops\\"];
+"
+`;
+
+exports[`ambiguous > config > default > ["oops"] > with semi, without newline > it formats ../cases/gts/component-class.gts 1`] = `
+"import Component from \\"@glimmer/component\\";
+
+export interface Signature {
+  Element: HTMLElement;
+  Args: {
+    myArg: string;
+  };
+  Yields: [];
+}
+
+/** It's a component */
+class MyComponent extends Component<Signature> {
+  <template>
+    <h1>
+      Class top level template. Class top level template. Class top level
+      template. Class top level template. Class top level template.
+    </h1>
+  </template>
+  [\\"oops\\"];
+}
+"
+`;
+
+exports[`ambiguous > config > default > ["oops"] > with semi, without newline > it formats ../cases/gts/default-export.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
+
+export interface Signature {
+  Element: HTMLElement;
+  Args: {};
+  Yields: [];
+}
+
+<template>
+  Explicit default export module top level component. Explicit default export
+  module top level component. Explicit default export module top level
+  component. Explicit default export module top level component. Explicit
+  default export module top level component.
+</template> as TemplateOnlyComponent<Signature>;
+[\\"oops\\"];
+"
+`;
+
+exports[`ambiguous > config > default > ["oops"] > with semi, without newline > it formats ../cases/gts/exported-mod-var.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
+
+export interface Signature {
+  Element: HTMLElement;
+  Args: {};
+  Yields: [];
+}
+
+export const Exported: TemplateOnlyComponent<Signature> = <template>
+  Exported variable template. Exported variable template. Exported variable
+  template. Exported variable template. Exported variable template. Exported
+  variable template. Exported variable template.
+</template>;
+[\\"oops\\"];
+"
+`;
+
+exports[`ambiguous > config > default > ["oops"] > with semi, without newline > it formats ../cases/gts/exported-mod-var-with-as.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
+
+export interface Signature {
+  Element: HTMLElement;
+  Args: {};
+  Yields: [];
+}
+
+export const Exported = <template>
+  Exported variable template. Exported variable template. Exported variable
+  template. Exported variable template. Exported variable template. Exported
+  variable template. Exported variable template.
+</template> as TemplateOnlyComponent<Signature>;
+[\\"oops\\"];
+"
+`;
+
+exports[`ambiguous > config > default > ["oops"] > with semi, without newline > it formats ../cases/gts/js-only.gts 1`] = `
+"const num: number = 1;
+[\\"oops\\"];
+"
+`;
+
+exports[`ambiguous > config > default > ["oops"] > with semi, without newline > it formats ../cases/gts/mod-var.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
+
+export interface Signature {
+  Element: HTMLElement;
+  Args: {};
+  Yields: [];
+}
+
+const Private: TemplateOnlyComponent<Signature> = <template>
+  Private variable template. Private variable template. Private variable
+  template. Private variable template. Private variable template. Private
+  variable template. Private variable template.
+</template>;
+[\\"oops\\"];
+"
+`;
+
+exports[`ambiguous > config > default > ["oops"] > with semi, without newline > it formats ../cases/gts/mod-var-with-as.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
+
+export interface Signature {
+  Element: HTMLElement;
+  Args: {};
+  Yields: [];
+}
+
+const Private = <template>
+  Private variable template. Private variable template. Private variable
+  template. Private variable template. Private variable template. Private
+  variable template. Private variable template.
+</template> as TemplateOnlyComponent<Signature>;
+[\\"oops\\"];
+"
+`;
+
+exports[`ambiguous > config > default > ["oops"] > with semi, without newline > it formats ../cases/gts/multiple-declarations.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
+
+export interface Signature {
+  Element: HTMLElement;
+  Args: {};
+  Yields: [];
+}
+
+const ModVar1: TemplateOnlyComponent<Signature> = <template>
+    <h1>
+      Module variable template. Module variable template. Module variable
+      template. Module variable template. Module variable template. Module
+      variable template. Module variable template. Module variable template.
+    </h1>
+  </template>,
+  ModVar2: TemplateOnlyComponent<Signature> = <template>
+    Second module variable template.
+  </template>,
+  num = 1;
+[\\"oops\\"];
+
+const bool: boolean = false,
+  ModVar3: TemplateOnlyComponent<Signature> = <template>
+    <h1>
+      Module variable template. Module variable template. Module variable
+      template. Module variable template. Module variable template. Module
+      variable template. Module variable template. Module variable template.
+    </h1>
+  </template>,
+  ModVar4: TemplateOnlyComponent<Signature> = <template>
+    Second module variable template.
+  </template>;
+[\\"oops\\"];
+"
+`;
+
+exports[`ambiguous > config > default > ["oops"] > with semi, without newline > it formats ../cases/gts/multiple-declarations-with-as.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
+
+export interface Signature {
+  Element: HTMLElement;
+  Args: {};
+  Yields: [];
+}
+
+const ModVar1 = <template>
+    <h1>
+      Module variable template. Module variable template. Module variable
+      template. Module variable template. Module variable template. Module
+      variable template. Module variable template. Module variable template.
+    </h1>
+  </template> as TemplateOnlyComponent<Signature>,
+  ModVar2 = <template>
+    Second module variable template.
+  </template> as TemplateOnlyComponent<Signature>,
+  num = 1;
+[\\"oops\\"];
+
+const bool: boolean = false,
+  ModVar3 = <template>
+    <h1>
+      Module variable template. Module variable template. Module variable
+      template. Module variable template. Module variable template. Module
+      variable template. Module variable template. Module variable template.
+    </h1>
+  </template> as TemplateOnlyComponent<Signature>,
+  ModVar4 = <template>
+    Second module variable template.
+  </template> as TemplateOnlyComponent<Signature>;
+[\\"oops\\"];
+"
+`;
+
+exports[`ambiguous > config > default > ["oops"] > with semi, without newline > it formats ../cases/gts/simple.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
+
+export interface Signature {
+  Element: HTMLElement;
+  Args: {};
+  Yields: [];
+}
+
+<template>
+  what
+</template> as TemplateOnlyComponent<Signature>;
+[\\"oops\\"];
+"
+`;
+
 exports[`ambiguous > config > default > ["oops"] > without semi, with newline > it formats ../cases/gjs/component-class.gjs 1`] = `
 "import Component from \\"@glimmer/component\\";
 
@@ -5117,6 +6768,266 @@ export interface Signature {
 "
 `;
 
+exports[`ambiguous > config > default > \`oops\` > with semi, without newline > it formats ../cases/gjs/default-export.gjs 1`] = `
+"<template>
+  Explicit default export module top level component. Explicit default export
+  module top level component. Explicit default export module top level
+  component. Explicit default export module top level component. Explicit
+  default export module top level component.
+</template>
+\`oops\`;
+"
+`;
+
+exports[`ambiguous > config > default > \`oops\` > with semi, without newline > it formats ../cases/gjs/exported-mod-var.gjs 1`] = `
+"export const Exported = <template>
+  Exported variable template. Exported variable template. Exported variable
+  template. Exported variable template. Exported variable template. Exported
+  variable template. Exported variable template.
+</template>;
+\`oops\`;
+"
+`;
+
+exports[`ambiguous > config > default > \`oops\` > with semi, without newline > it formats ../cases/gjs/js-only.gjs 1`] = `
+"const num = 1;
+\`oops\`;
+"
+`;
+
+exports[`ambiguous > config > default > \`oops\` > with semi, without newline > it formats ../cases/gjs/mod-var.gjs 1`] = `
+"const Private = <template>
+  Private variable template. Private variable template. Private variable
+  template. Private variable template. Private variable template. Private
+  variable template. Private variable template.
+</template>;
+\`oops\`;
+
+const What = <template>Hi</template>;
+\`oops\`;
+"
+`;
+
+exports[`ambiguous > config > default > \`oops\` > with semi, without newline > it formats ../cases/gjs/multiple-declarations.gjs 1`] = `
+"const ModVar1 = <template>
+    <h1>
+      Module variable template. Module variable template. Module variable
+      template. Module variable template. Module variable template. Module
+      variable template. Module variable template. Module variable template.
+    </h1>
+  </template>,
+  ModVar2 = <template>Second module variable template.</template>,
+  num = 1;
+\`oops\`;
+
+const bool = false,
+  ModVar3 = <template>
+    <h1>
+      Module variable template. Module variable template. Module variable
+      template. Module variable template. Module variable template. Module
+      variable template. Module variable template. Module variable template.
+    </h1>
+  </template>,
+  ModVar4 = <template>Second module variable template.</template>;
+\`oops\`;
+"
+`;
+
+exports[`ambiguous > config > default > \`oops\` > with semi, without newline > it formats ../cases/gjs/simple.gjs 1`] = `
+"<template>
+  what
+</template>
+\`oops\`;
+"
+`;
+
+exports[`ambiguous > config > default > \`oops\` > with semi, without newline > it formats ../cases/gts/default-export.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
+
+export interface Signature {
+  Element: HTMLElement;
+  Args: {};
+  Yields: [];
+}
+
+<template>
+  Explicit default export module top level component. Explicit default export
+  module top level component. Explicit default export module top level
+  component. Explicit default export module top level component. Explicit
+  default export module top level component.
+</template> as TemplateOnlyComponent<Signature>
+\`oops\`;
+"
+`;
+
+exports[`ambiguous > config > default > \`oops\` > with semi, without newline > it formats ../cases/gts/exported-mod-var.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
+
+export interface Signature {
+  Element: HTMLElement;
+  Args: {};
+  Yields: [];
+}
+
+export const Exported: TemplateOnlyComponent<Signature> = <template>
+  Exported variable template. Exported variable template. Exported variable
+  template. Exported variable template. Exported variable template. Exported
+  variable template. Exported variable template.
+</template>;
+\`oops\`;
+"
+`;
+
+exports[`ambiguous > config > default > \`oops\` > with semi, without newline > it formats ../cases/gts/exported-mod-var-with-as.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
+
+export interface Signature {
+  Element: HTMLElement;
+  Args: {};
+  Yields: [];
+}
+
+export const Exported = <template>
+  Exported variable template. Exported variable template. Exported variable
+  template. Exported variable template. Exported variable template. Exported
+  variable template. Exported variable template.
+</template> as TemplateOnlyComponent<Signature>;
+\`oops\`;
+"
+`;
+
+exports[`ambiguous > config > default > \`oops\` > with semi, without newline > it formats ../cases/gts/js-only.gts 1`] = `
+"const num: number = 1;
+\`oops\`;
+"
+`;
+
+exports[`ambiguous > config > default > \`oops\` > with semi, without newline > it formats ../cases/gts/mod-var.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
+
+export interface Signature {
+  Element: HTMLElement;
+  Args: {};
+  Yields: [];
+}
+
+const Private: TemplateOnlyComponent<Signature> = <template>
+  Private variable template. Private variable template. Private variable
+  template. Private variable template. Private variable template. Private
+  variable template. Private variable template.
+</template>;
+\`oops\`;
+"
+`;
+
+exports[`ambiguous > config > default > \`oops\` > with semi, without newline > it formats ../cases/gts/mod-var-with-as.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
+
+export interface Signature {
+  Element: HTMLElement;
+  Args: {};
+  Yields: [];
+}
+
+const Private = <template>
+  Private variable template. Private variable template. Private variable
+  template. Private variable template. Private variable template. Private
+  variable template. Private variable template.
+</template> as TemplateOnlyComponent<Signature>;
+\`oops\`;
+"
+`;
+
+exports[`ambiguous > config > default > \`oops\` > with semi, without newline > it formats ../cases/gts/multiple-declarations.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
+
+export interface Signature {
+  Element: HTMLElement;
+  Args: {};
+  Yields: [];
+}
+
+const ModVar1: TemplateOnlyComponent<Signature> = <template>
+    <h1>
+      Module variable template. Module variable template. Module variable
+      template. Module variable template. Module variable template. Module
+      variable template. Module variable template. Module variable template.
+    </h1>
+  </template>,
+  ModVar2: TemplateOnlyComponent<Signature> = <template>
+    Second module variable template.
+  </template>,
+  num = 1;
+\`oops\`;
+
+const bool: boolean = false,
+  ModVar3: TemplateOnlyComponent<Signature> = <template>
+    <h1>
+      Module variable template. Module variable template. Module variable
+      template. Module variable template. Module variable template. Module
+      variable template. Module variable template. Module variable template.
+    </h1>
+  </template>,
+  ModVar4: TemplateOnlyComponent<Signature> = <template>
+    Second module variable template.
+  </template>;
+\`oops\`;
+"
+`;
+
+exports[`ambiguous > config > default > \`oops\` > with semi, without newline > it formats ../cases/gts/multiple-declarations-with-as.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
+
+export interface Signature {
+  Element: HTMLElement;
+  Args: {};
+  Yields: [];
+}
+
+const ModVar1 = <template>
+    <h1>
+      Module variable template. Module variable template. Module variable
+      template. Module variable template. Module variable template. Module
+      variable template. Module variable template. Module variable template.
+    </h1>
+  </template> as TemplateOnlyComponent<Signature>,
+  ModVar2 = <template>
+    Second module variable template.
+  </template> as TemplateOnlyComponent<Signature>,
+  num = 1;
+\`oops\`;
+
+const bool: boolean = false,
+  ModVar3 = <template>
+    <h1>
+      Module variable template. Module variable template. Module variable
+      template. Module variable template. Module variable template. Module
+      variable template. Module variable template. Module variable template.
+    </h1>
+  </template> as TemplateOnlyComponent<Signature>,
+  ModVar4 = <template>
+    Second module variable template.
+  </template> as TemplateOnlyComponent<Signature>;
+\`oops\`;
+"
+`;
+
+exports[`ambiguous > config > default > \`oops\` > with semi, without newline > it formats ../cases/gts/simple.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
+
+export interface Signature {
+  Element: HTMLElement;
+  Args: {};
+  Yields: [];
+}
+
+<template>
+  what
+</template> as TemplateOnlyComponent<Signature>
+\`oops\`;
+"
+`;
+
 exports[`ambiguous > config > default > \`oops\` > without semi, with newline > it formats ../cases/gjs/js-only.gjs 1`] = `
 "const num = 1\`oops\`;
 "
@@ -5851,6 +7762,266 @@ export interface Signature {
 `;
 
 exports[`ambiguous > config > default > -"oops" > with semi, with newline > it formats ../cases/gts/simple.gts 2`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
+
+export interface Signature {
+  Element: HTMLElement;
+  Args: {};
+  Yields: [];
+}
+
+<template>
+  what
+</template> as TemplateOnlyComponent<Signature>;
+-\\"oops\\";
+"
+`;
+
+exports[`ambiguous > config > default > -"oops" > with semi, without newline > it formats ../cases/gjs/default-export.gjs 1`] = `
+"<template>
+  Explicit default export module top level component. Explicit default export
+  module top level component. Explicit default export module top level
+  component. Explicit default export module top level component. Explicit
+  default export module top level component.
+</template>;
+-\\"oops\\";
+"
+`;
+
+exports[`ambiguous > config > default > -"oops" > with semi, without newline > it formats ../cases/gjs/exported-mod-var.gjs 1`] = `
+"export const Exported = <template>
+  Exported variable template. Exported variable template. Exported variable
+  template. Exported variable template. Exported variable template. Exported
+  variable template. Exported variable template.
+</template>;
+-\\"oops\\";
+"
+`;
+
+exports[`ambiguous > config > default > -"oops" > with semi, without newline > it formats ../cases/gjs/js-only.gjs 1`] = `
+"const num = 1;
+-\\"oops\\";
+"
+`;
+
+exports[`ambiguous > config > default > -"oops" > with semi, without newline > it formats ../cases/gjs/mod-var.gjs 1`] = `
+"const Private = <template>
+  Private variable template. Private variable template. Private variable
+  template. Private variable template. Private variable template. Private
+  variable template. Private variable template.
+</template>;
+-\\"oops\\";
+
+const What = <template>Hi</template>;
+-\\"oops\\";
+"
+`;
+
+exports[`ambiguous > config > default > -"oops" > with semi, without newline > it formats ../cases/gjs/multiple-declarations.gjs 1`] = `
+"const ModVar1 = <template>
+    <h1>
+      Module variable template. Module variable template. Module variable
+      template. Module variable template. Module variable template. Module
+      variable template. Module variable template. Module variable template.
+    </h1>
+  </template>,
+  ModVar2 = <template>Second module variable template.</template>,
+  num = 1;
+-\\"oops\\";
+
+const bool = false,
+  ModVar3 = <template>
+    <h1>
+      Module variable template. Module variable template. Module variable
+      template. Module variable template. Module variable template. Module
+      variable template. Module variable template. Module variable template.
+    </h1>
+  </template>,
+  ModVar4 = <template>Second module variable template.</template>;
+-\\"oops\\";
+"
+`;
+
+exports[`ambiguous > config > default > -"oops" > with semi, without newline > it formats ../cases/gjs/simple.gjs 1`] = `
+"<template>
+  what
+</template>;
+-\\"oops\\";
+"
+`;
+
+exports[`ambiguous > config > default > -"oops" > with semi, without newline > it formats ../cases/gts/default-export.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
+
+export interface Signature {
+  Element: HTMLElement;
+  Args: {};
+  Yields: [];
+}
+
+<template>
+  Explicit default export module top level component. Explicit default export
+  module top level component. Explicit default export module top level
+  component. Explicit default export module top level component. Explicit
+  default export module top level component.
+</template> as TemplateOnlyComponent<Signature>;
+-\\"oops\\";
+"
+`;
+
+exports[`ambiguous > config > default > -"oops" > with semi, without newline > it formats ../cases/gts/exported-mod-var.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
+
+export interface Signature {
+  Element: HTMLElement;
+  Args: {};
+  Yields: [];
+}
+
+export const Exported: TemplateOnlyComponent<Signature> = <template>
+  Exported variable template. Exported variable template. Exported variable
+  template. Exported variable template. Exported variable template. Exported
+  variable template. Exported variable template.
+</template>;
+-\\"oops\\";
+"
+`;
+
+exports[`ambiguous > config > default > -"oops" > with semi, without newline > it formats ../cases/gts/exported-mod-var-with-as.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
+
+export interface Signature {
+  Element: HTMLElement;
+  Args: {};
+  Yields: [];
+}
+
+export const Exported = <template>
+  Exported variable template. Exported variable template. Exported variable
+  template. Exported variable template. Exported variable template. Exported
+  variable template. Exported variable template.
+</template> as TemplateOnlyComponent<Signature>;
+-\\"oops\\";
+"
+`;
+
+exports[`ambiguous > config > default > -"oops" > with semi, without newline > it formats ../cases/gts/js-only.gts 1`] = `
+"const num: number = 1;
+-\\"oops\\";
+"
+`;
+
+exports[`ambiguous > config > default > -"oops" > with semi, without newline > it formats ../cases/gts/mod-var.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
+
+export interface Signature {
+  Element: HTMLElement;
+  Args: {};
+  Yields: [];
+}
+
+const Private: TemplateOnlyComponent<Signature> = <template>
+  Private variable template. Private variable template. Private variable
+  template. Private variable template. Private variable template. Private
+  variable template. Private variable template.
+</template>;
+-\\"oops\\";
+"
+`;
+
+exports[`ambiguous > config > default > -"oops" > with semi, without newline > it formats ../cases/gts/mod-var-with-as.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
+
+export interface Signature {
+  Element: HTMLElement;
+  Args: {};
+  Yields: [];
+}
+
+const Private = <template>
+  Private variable template. Private variable template. Private variable
+  template. Private variable template. Private variable template. Private
+  variable template. Private variable template.
+</template> as TemplateOnlyComponent<Signature>;
+-\\"oops\\";
+"
+`;
+
+exports[`ambiguous > config > default > -"oops" > with semi, without newline > it formats ../cases/gts/multiple-declarations.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
+
+export interface Signature {
+  Element: HTMLElement;
+  Args: {};
+  Yields: [];
+}
+
+const ModVar1: TemplateOnlyComponent<Signature> = <template>
+    <h1>
+      Module variable template. Module variable template. Module variable
+      template. Module variable template. Module variable template. Module
+      variable template. Module variable template. Module variable template.
+    </h1>
+  </template>,
+  ModVar2: TemplateOnlyComponent<Signature> = <template>
+    Second module variable template.
+  </template>,
+  num = 1;
+-\\"oops\\";
+
+const bool: boolean = false,
+  ModVar3: TemplateOnlyComponent<Signature> = <template>
+    <h1>
+      Module variable template. Module variable template. Module variable
+      template. Module variable template. Module variable template. Module
+      variable template. Module variable template. Module variable template.
+    </h1>
+  </template>,
+  ModVar4: TemplateOnlyComponent<Signature> = <template>
+    Second module variable template.
+  </template>;
+-\\"oops\\";
+"
+`;
+
+exports[`ambiguous > config > default > -"oops" > with semi, without newline > it formats ../cases/gts/multiple-declarations-with-as.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
+
+export interface Signature {
+  Element: HTMLElement;
+  Args: {};
+  Yields: [];
+}
+
+const ModVar1 = <template>
+    <h1>
+      Module variable template. Module variable template. Module variable
+      template. Module variable template. Module variable template. Module
+      variable template. Module variable template. Module variable template.
+    </h1>
+  </template> as TemplateOnlyComponent<Signature>,
+  ModVar2 = <template>
+    Second module variable template.
+  </template> as TemplateOnlyComponent<Signature>,
+  num = 1;
+-\\"oops\\";
+
+const bool: boolean = false,
+  ModVar3 = <template>
+    <h1>
+      Module variable template. Module variable template. Module variable
+      template. Module variable template. Module variable template. Module
+      variable template. Module variable template. Module variable template.
+    </h1>
+  </template> as TemplateOnlyComponent<Signature>,
+  ModVar4 = <template>
+    Second module variable template.
+  </template> as TemplateOnlyComponent<Signature>;
+-\\"oops\\";
+"
+`;
+
+exports[`ambiguous > config > default > -"oops" > with semi, without newline > it formats ../cases/gts/simple.gts 1`] = `
 "import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
 
 export interface Signature {

--- a/tests/unit-tests/ambiguous/__snapshots__/index.test.ts.snap
+++ b/tests/unit-tests/ambiguous/__snapshots__/index.test.ts.snap
@@ -11,28 +11,7 @@ exports[`ambiguous > config > default > (oh, no) => {} > with semi, with newline
 "
 `;
 
-exports[`ambiguous > config > default > (oh, no) => {} > with semi, with newline > it formats ../cases/gjs/default-export.gjs 2`] = `
-"<template>
-  Explicit default export module top level component. Explicit default export
-  module top level component. Explicit default export module top level
-  component. Explicit default export module top level component. Explicit
-  default export module top level component.
-</template>;
-(oh, no) => {};
-"
-`;
-
 exports[`ambiguous > config > default > (oh, no) => {} > with semi, with newline > it formats ../cases/gjs/exported-mod-var.gjs 1`] = `
-"export const Exported = <template>
-  Exported variable template. Exported variable template. Exported variable
-  template. Exported variable template. Exported variable template. Exported
-  variable template. Exported variable template.
-</template>;
-(oh, no) => {};
-"
-`;
-
-exports[`ambiguous > config > default > (oh, no) => {} > with semi, with newline > it formats ../cases/gjs/exported-mod-var.gjs 2`] = `
 "export const Exported = <template>
   Exported variable template. Exported variable template. Exported variable
   template. Exported variable template. Exported variable template. Exported
@@ -48,26 +27,7 @@ exports[`ambiguous > config > default > (oh, no) => {} > with semi, with newline
 "
 `;
 
-exports[`ambiguous > config > default > (oh, no) => {} > with semi, with newline > it formats ../cases/gjs/js-only.gjs 2`] = `
-"const num = 1;
-(oh, no) => {};
-"
-`;
-
 exports[`ambiguous > config > default > (oh, no) => {} > with semi, with newline > it formats ../cases/gjs/mod-var.gjs 1`] = `
-"const Private = <template>
-  Private variable template. Private variable template. Private variable
-  template. Private variable template. Private variable template. Private
-  variable template. Private variable template.
-</template>;
-(oh, no) => {};
-
-const What = <template>Hi</template>;
-(oh, no) => {};
-"
-`;
-
-exports[`ambiguous > config > default > (oh, no) => {} > with semi, with newline > it formats ../cases/gjs/mod-var.gjs 2`] = `
 "const Private = <template>
   Private variable template. Private variable template. Private variable
   template. Private variable template. Private variable template. Private
@@ -105,31 +65,6 @@ const bool = false,
 "
 `;
 
-exports[`ambiguous > config > default > (oh, no) => {} > with semi, with newline > it formats ../cases/gjs/multiple-declarations.gjs 2`] = `
-"const ModVar1 = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template>,
-  ModVar2 = <template>Second module variable template.</template>,
-  num = 1;
-(oh, no) => {};
-
-const bool = false,
-  ModVar3 = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template>,
-  ModVar4 = <template>Second module variable template.</template>;
-(oh, no) => {};
-"
-`;
-
 exports[`ambiguous > config > default > (oh, no) => {} > with semi, with newline > it formats ../cases/gjs/simple.gjs 1`] = `
 "<template>
   what
@@ -138,34 +73,7 @@ exports[`ambiguous > config > default > (oh, no) => {} > with semi, with newline
 "
 `;
 
-exports[`ambiguous > config > default > (oh, no) => {} > with semi, with newline > it formats ../cases/gjs/simple.gjs 2`] = `
-"<template>
-  what
-</template>;
-(oh, no) => {};
-"
-`;
-
 exports[`ambiguous > config > default > (oh, no) => {} > with semi, with newline > it formats ../cases/gts/default-export.gts 1`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
-
-export interface Signature {
-  Element: HTMLElement;
-  Args: {};
-  Yields: [];
-}
-
-<template>
-  Explicit default export module top level component. Explicit default export
-  module top level component. Explicit default export module top level
-  component. Explicit default export module top level component. Explicit
-  default export module top level component.
-</template> as TemplateOnlyComponent<Signature>;
-(oh, no) => {};
-"
-`;
-
-exports[`ambiguous > config > default > (oh, no) => {} > with semi, with newline > it formats ../cases/gts/default-export.gts 2`] = `
 "import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
 
 export interface Signature {
@@ -202,43 +110,7 @@ export const Exported: TemplateOnlyComponent<Signature> = <template>
 "
 `;
 
-exports[`ambiguous > config > default > (oh, no) => {} > with semi, with newline > it formats ../cases/gts/exported-mod-var.gts 2`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
-
-export interface Signature {
-  Element: HTMLElement;
-  Args: {};
-  Yields: [];
-}
-
-export const Exported: TemplateOnlyComponent<Signature> = <template>
-  Exported variable template. Exported variable template. Exported variable
-  template. Exported variable template. Exported variable template. Exported
-  variable template. Exported variable template.
-</template>;
-(oh, no) => {};
-"
-`;
-
 exports[`ambiguous > config > default > (oh, no) => {} > with semi, with newline > it formats ../cases/gts/exported-mod-var-with-as.gts 1`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
-
-export interface Signature {
-  Element: HTMLElement;
-  Args: {};
-  Yields: [];
-}
-
-export const Exported = <template>
-  Exported variable template. Exported variable template. Exported variable
-  template. Exported variable template. Exported variable template. Exported
-  variable template. Exported variable template.
-</template> as TemplateOnlyComponent<Signature>;
-(oh, no) => {};
-"
-`;
-
-exports[`ambiguous > config > default > (oh, no) => {} > with semi, with newline > it formats ../cases/gts/exported-mod-var-with-as.gts 2`] = `
 "import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
 
 export interface Signature {
@@ -262,31 +134,7 @@ exports[`ambiguous > config > default > (oh, no) => {} > with semi, with newline
 "
 `;
 
-exports[`ambiguous > config > default > (oh, no) => {} > with semi, with newline > it formats ../cases/gts/js-only.gts 2`] = `
-"const num: number = 1;
-(oh, no) => {};
-"
-`;
-
 exports[`ambiguous > config > default > (oh, no) => {} > with semi, with newline > it formats ../cases/gts/mod-var.gts 1`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
-
-export interface Signature {
-  Element: HTMLElement;
-  Args: {};
-  Yields: [];
-}
-
-const Private: TemplateOnlyComponent<Signature> = <template>
-  Private variable template. Private variable template. Private variable
-  template. Private variable template. Private variable template. Private
-  variable template. Private variable template.
-</template>;
-(oh, no) => {};
-"
-`;
-
-exports[`ambiguous > config > default > (oh, no) => {} > with semi, with newline > it formats ../cases/gts/mod-var.gts 2`] = `
 "import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
 
 export interface Signature {
@@ -322,62 +170,7 @@ const Private = <template>
 "
 `;
 
-exports[`ambiguous > config > default > (oh, no) => {} > with semi, with newline > it formats ../cases/gts/mod-var-with-as.gts 2`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
-
-export interface Signature {
-  Element: HTMLElement;
-  Args: {};
-  Yields: [];
-}
-
-const Private = <template>
-  Private variable template. Private variable template. Private variable
-  template. Private variable template. Private variable template. Private
-  variable template. Private variable template.
-</template> as TemplateOnlyComponent<Signature>;
-(oh, no) => {};
-"
-`;
-
 exports[`ambiguous > config > default > (oh, no) => {} > with semi, with newline > it formats ../cases/gts/multiple-declarations.gts 1`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
-
-export interface Signature {
-  Element: HTMLElement;
-  Args: {};
-  Yields: [];
-}
-
-const ModVar1: TemplateOnlyComponent<Signature> = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template>,
-  ModVar2: TemplateOnlyComponent<Signature> = <template>
-    Second module variable template.
-  </template>,
-  num = 1;
-(oh, no) => {};
-
-const bool: boolean = false,
-  ModVar3: TemplateOnlyComponent<Signature> = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template>,
-  ModVar4: TemplateOnlyComponent<Signature> = <template>
-    Second module variable template.
-  </template>;
-(oh, no) => {};
-"
-`;
-
-exports[`ambiguous > config > default > (oh, no) => {} > with semi, with newline > it formats ../cases/gts/multiple-declarations.gts 2`] = `
 "import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
 
 export interface Signature {
@@ -451,60 +244,7 @@ const bool: boolean = false,
 "
 `;
 
-exports[`ambiguous > config > default > (oh, no) => {} > with semi, with newline > it formats ../cases/gts/multiple-declarations-with-as.gts 2`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
-
-export interface Signature {
-  Element: HTMLElement;
-  Args: {};
-  Yields: [];
-}
-
-const ModVar1 = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template> as TemplateOnlyComponent<Signature>,
-  ModVar2 = <template>
-    Second module variable template.
-  </template> as TemplateOnlyComponent<Signature>,
-  num = 1;
-(oh, no) => {};
-
-const bool: boolean = false,
-  ModVar3 = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template> as TemplateOnlyComponent<Signature>,
-  ModVar4 = <template>
-    Second module variable template.
-  </template> as TemplateOnlyComponent<Signature>;
-(oh, no) => {};
-"
-`;
-
 exports[`ambiguous > config > default > (oh, no) => {} > with semi, with newline > it formats ../cases/gts/simple.gts 1`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
-
-export interface Signature {
-  Element: HTMLElement;
-  Args: {};
-  Yields: [];
-}
-
-<template>
-  what
-</template> as TemplateOnlyComponent<Signature>;
-(oh, no) => {};
-"
-`;
-
-exports[`ambiguous > config > default > (oh, no) => {} > with semi, with newline > it formats ../cases/gts/simple.gts 2`] = `
 "import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
 
 export interface Signature {
@@ -929,28 +669,7 @@ exports[`ambiguous > config > default > (oops) => {} > with semi, with newline >
 "
 `;
 
-exports[`ambiguous > config > default > (oops) => {} > with semi, with newline > it formats ../cases/gjs/default-export.gjs 2`] = `
-"<template>
-  Explicit default export module top level component. Explicit default export
-  module top level component. Explicit default export module top level
-  component. Explicit default export module top level component. Explicit
-  default export module top level component.
-</template>;
-(oops) => {};
-"
-`;
-
 exports[`ambiguous > config > default > (oops) => {} > with semi, with newline > it formats ../cases/gjs/exported-mod-var.gjs 1`] = `
-"export const Exported = <template>
-  Exported variable template. Exported variable template. Exported variable
-  template. Exported variable template. Exported variable template. Exported
-  variable template. Exported variable template.
-</template>;
-(oops) => {};
-"
-`;
-
-exports[`ambiguous > config > default > (oops) => {} > with semi, with newline > it formats ../cases/gjs/exported-mod-var.gjs 2`] = `
 "export const Exported = <template>
   Exported variable template. Exported variable template. Exported variable
   template. Exported variable template. Exported variable template. Exported
@@ -966,26 +685,7 @@ exports[`ambiguous > config > default > (oops) => {} > with semi, with newline >
 "
 `;
 
-exports[`ambiguous > config > default > (oops) => {} > with semi, with newline > it formats ../cases/gjs/js-only.gjs 2`] = `
-"const num = 1;
-(oops) => {};
-"
-`;
-
 exports[`ambiguous > config > default > (oops) => {} > with semi, with newline > it formats ../cases/gjs/mod-var.gjs 1`] = `
-"const Private = <template>
-  Private variable template. Private variable template. Private variable
-  template. Private variable template. Private variable template. Private
-  variable template. Private variable template.
-</template>;
-(oops) => {};
-
-const What = <template>Hi</template>;
-(oops) => {};
-"
-`;
-
-exports[`ambiguous > config > default > (oops) => {} > with semi, with newline > it formats ../cases/gjs/mod-var.gjs 2`] = `
 "const Private = <template>
   Private variable template. Private variable template. Private variable
   template. Private variable template. Private variable template. Private
@@ -1023,31 +723,6 @@ const bool = false,
 "
 `;
 
-exports[`ambiguous > config > default > (oops) => {} > with semi, with newline > it formats ../cases/gjs/multiple-declarations.gjs 2`] = `
-"const ModVar1 = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template>,
-  ModVar2 = <template>Second module variable template.</template>,
-  num = 1;
-(oops) => {};
-
-const bool = false,
-  ModVar3 = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template>,
-  ModVar4 = <template>Second module variable template.</template>;
-(oops) => {};
-"
-`;
-
 exports[`ambiguous > config > default > (oops) => {} > with semi, with newline > it formats ../cases/gjs/simple.gjs 1`] = `
 "<template>
   what
@@ -1056,34 +731,7 @@ exports[`ambiguous > config > default > (oops) => {} > with semi, with newline >
 "
 `;
 
-exports[`ambiguous > config > default > (oops) => {} > with semi, with newline > it formats ../cases/gjs/simple.gjs 2`] = `
-"<template>
-  what
-</template>;
-(oops) => {};
-"
-`;
-
 exports[`ambiguous > config > default > (oops) => {} > with semi, with newline > it formats ../cases/gts/default-export.gts 1`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
-
-export interface Signature {
-  Element: HTMLElement;
-  Args: {};
-  Yields: [];
-}
-
-<template>
-  Explicit default export module top level component. Explicit default export
-  module top level component. Explicit default export module top level
-  component. Explicit default export module top level component. Explicit
-  default export module top level component.
-</template> as TemplateOnlyComponent<Signature>;
-(oops) => {};
-"
-`;
-
-exports[`ambiguous > config > default > (oops) => {} > with semi, with newline > it formats ../cases/gts/default-export.gts 2`] = `
 "import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
 
 export interface Signature {
@@ -1120,43 +768,7 @@ export const Exported: TemplateOnlyComponent<Signature> = <template>
 "
 `;
 
-exports[`ambiguous > config > default > (oops) => {} > with semi, with newline > it formats ../cases/gts/exported-mod-var.gts 2`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
-
-export interface Signature {
-  Element: HTMLElement;
-  Args: {};
-  Yields: [];
-}
-
-export const Exported: TemplateOnlyComponent<Signature> = <template>
-  Exported variable template. Exported variable template. Exported variable
-  template. Exported variable template. Exported variable template. Exported
-  variable template. Exported variable template.
-</template>;
-(oops) => {};
-"
-`;
-
 exports[`ambiguous > config > default > (oops) => {} > with semi, with newline > it formats ../cases/gts/exported-mod-var-with-as.gts 1`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
-
-export interface Signature {
-  Element: HTMLElement;
-  Args: {};
-  Yields: [];
-}
-
-export const Exported = <template>
-  Exported variable template. Exported variable template. Exported variable
-  template. Exported variable template. Exported variable template. Exported
-  variable template. Exported variable template.
-</template> as TemplateOnlyComponent<Signature>;
-(oops) => {};
-"
-`;
-
-exports[`ambiguous > config > default > (oops) => {} > with semi, with newline > it formats ../cases/gts/exported-mod-var-with-as.gts 2`] = `
 "import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
 
 export interface Signature {
@@ -1180,31 +792,7 @@ exports[`ambiguous > config > default > (oops) => {} > with semi, with newline >
 "
 `;
 
-exports[`ambiguous > config > default > (oops) => {} > with semi, with newline > it formats ../cases/gts/js-only.gts 2`] = `
-"const num: number = 1;
-(oops) => {};
-"
-`;
-
 exports[`ambiguous > config > default > (oops) => {} > with semi, with newline > it formats ../cases/gts/mod-var.gts 1`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
-
-export interface Signature {
-  Element: HTMLElement;
-  Args: {};
-  Yields: [];
-}
-
-const Private: TemplateOnlyComponent<Signature> = <template>
-  Private variable template. Private variable template. Private variable
-  template. Private variable template. Private variable template. Private
-  variable template. Private variable template.
-</template>;
-(oops) => {};
-"
-`;
-
-exports[`ambiguous > config > default > (oops) => {} > with semi, with newline > it formats ../cases/gts/mod-var.gts 2`] = `
 "import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
 
 export interface Signature {
@@ -1240,62 +828,7 @@ const Private = <template>
 "
 `;
 
-exports[`ambiguous > config > default > (oops) => {} > with semi, with newline > it formats ../cases/gts/mod-var-with-as.gts 2`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
-
-export interface Signature {
-  Element: HTMLElement;
-  Args: {};
-  Yields: [];
-}
-
-const Private = <template>
-  Private variable template. Private variable template. Private variable
-  template. Private variable template. Private variable template. Private
-  variable template. Private variable template.
-</template> as TemplateOnlyComponent<Signature>;
-(oops) => {};
-"
-`;
-
 exports[`ambiguous > config > default > (oops) => {} > with semi, with newline > it formats ../cases/gts/multiple-declarations.gts 1`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
-
-export interface Signature {
-  Element: HTMLElement;
-  Args: {};
-  Yields: [];
-}
-
-const ModVar1: TemplateOnlyComponent<Signature> = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template>,
-  ModVar2: TemplateOnlyComponent<Signature> = <template>
-    Second module variable template.
-  </template>,
-  num = 1;
-(oops) => {};
-
-const bool: boolean = false,
-  ModVar3: TemplateOnlyComponent<Signature> = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template>,
-  ModVar4: TemplateOnlyComponent<Signature> = <template>
-    Second module variable template.
-  </template>;
-(oops) => {};
-"
-`;
-
-exports[`ambiguous > config > default > (oops) => {} > with semi, with newline > it formats ../cases/gts/multiple-declarations.gts 2`] = `
 "import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
 
 export interface Signature {
@@ -1369,60 +902,7 @@ const bool: boolean = false,
 "
 `;
 
-exports[`ambiguous > config > default > (oops) => {} > with semi, with newline > it formats ../cases/gts/multiple-declarations-with-as.gts 2`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
-
-export interface Signature {
-  Element: HTMLElement;
-  Args: {};
-  Yields: [];
-}
-
-const ModVar1 = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template> as TemplateOnlyComponent<Signature>,
-  ModVar2 = <template>
-    Second module variable template.
-  </template> as TemplateOnlyComponent<Signature>,
-  num = 1;
-(oops) => {};
-
-const bool: boolean = false,
-  ModVar3 = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template> as TemplateOnlyComponent<Signature>,
-  ModVar4 = <template>
-    Second module variable template.
-  </template> as TemplateOnlyComponent<Signature>;
-(oops) => {};
-"
-`;
-
 exports[`ambiguous > config > default > (oops) => {} > with semi, with newline > it formats ../cases/gts/simple.gts 1`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
-
-export interface Signature {
-  Element: HTMLElement;
-  Args: {};
-  Yields: [];
-}
-
-<template>
-  what
-</template> as TemplateOnlyComponent<Signature>;
-(oops) => {};
-"
-`;
-
-exports[`ambiguous > config > default > (oops) => {} > with semi, with newline > it formats ../cases/gts/simple.gts 2`] = `
 "import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
 
 export interface Signature {
@@ -1847,28 +1327,7 @@ exports[`ambiguous > config > default > +"oops" > with semi, with newline > it f
 "
 `;
 
-exports[`ambiguous > config > default > +"oops" > with semi, with newline > it formats ../cases/gjs/default-export.gjs 2`] = `
-"<template>
-  Explicit default export module top level component. Explicit default export
-  module top level component. Explicit default export module top level
-  component. Explicit default export module top level component. Explicit
-  default export module top level component.
-</template>;
-+\\"oops\\";
-"
-`;
-
 exports[`ambiguous > config > default > +"oops" > with semi, with newline > it formats ../cases/gjs/exported-mod-var.gjs 1`] = `
-"export const Exported = <template>
-  Exported variable template. Exported variable template. Exported variable
-  template. Exported variable template. Exported variable template. Exported
-  variable template. Exported variable template.
-</template>;
-+\\"oops\\";
-"
-`;
-
-exports[`ambiguous > config > default > +"oops" > with semi, with newline > it formats ../cases/gjs/exported-mod-var.gjs 2`] = `
 "export const Exported = <template>
   Exported variable template. Exported variable template. Exported variable
   template. Exported variable template. Exported variable template. Exported
@@ -1884,26 +1343,7 @@ exports[`ambiguous > config > default > +"oops" > with semi, with newline > it f
 "
 `;
 
-exports[`ambiguous > config > default > +"oops" > with semi, with newline > it formats ../cases/gjs/js-only.gjs 2`] = `
-"const num = 1;
-+\\"oops\\";
-"
-`;
-
 exports[`ambiguous > config > default > +"oops" > with semi, with newline > it formats ../cases/gjs/mod-var.gjs 1`] = `
-"const Private = <template>
-  Private variable template. Private variable template. Private variable
-  template. Private variable template. Private variable template. Private
-  variable template. Private variable template.
-</template>;
-+\\"oops\\";
-
-const What = <template>Hi</template>;
-+\\"oops\\";
-"
-`;
-
-exports[`ambiguous > config > default > +"oops" > with semi, with newline > it formats ../cases/gjs/mod-var.gjs 2`] = `
 "const Private = <template>
   Private variable template. Private variable template. Private variable
   template. Private variable template. Private variable template. Private
@@ -1941,31 +1381,6 @@ const bool = false,
 "
 `;
 
-exports[`ambiguous > config > default > +"oops" > with semi, with newline > it formats ../cases/gjs/multiple-declarations.gjs 2`] = `
-"const ModVar1 = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template>,
-  ModVar2 = <template>Second module variable template.</template>,
-  num = 1;
-+\\"oops\\";
-
-const bool = false,
-  ModVar3 = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template>,
-  ModVar4 = <template>Second module variable template.</template>;
-+\\"oops\\";
-"
-`;
-
 exports[`ambiguous > config > default > +"oops" > with semi, with newline > it formats ../cases/gjs/simple.gjs 1`] = `
 "<template>
   what
@@ -1974,34 +1389,7 @@ exports[`ambiguous > config > default > +"oops" > with semi, with newline > it f
 "
 `;
 
-exports[`ambiguous > config > default > +"oops" > with semi, with newline > it formats ../cases/gjs/simple.gjs 2`] = `
-"<template>
-  what
-</template>;
-+\\"oops\\";
-"
-`;
-
 exports[`ambiguous > config > default > +"oops" > with semi, with newline > it formats ../cases/gts/default-export.gts 1`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
-
-export interface Signature {
-  Element: HTMLElement;
-  Args: {};
-  Yields: [];
-}
-
-<template>
-  Explicit default export module top level component. Explicit default export
-  module top level component. Explicit default export module top level
-  component. Explicit default export module top level component. Explicit
-  default export module top level component.
-</template> as TemplateOnlyComponent<Signature>;
-+\\"oops\\";
-"
-`;
-
-exports[`ambiguous > config > default > +"oops" > with semi, with newline > it formats ../cases/gts/default-export.gts 2`] = `
 "import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
 
 export interface Signature {
@@ -2038,43 +1426,7 @@ export const Exported: TemplateOnlyComponent<Signature> = <template>
 "
 `;
 
-exports[`ambiguous > config > default > +"oops" > with semi, with newline > it formats ../cases/gts/exported-mod-var.gts 2`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
-
-export interface Signature {
-  Element: HTMLElement;
-  Args: {};
-  Yields: [];
-}
-
-export const Exported: TemplateOnlyComponent<Signature> = <template>
-  Exported variable template. Exported variable template. Exported variable
-  template. Exported variable template. Exported variable template. Exported
-  variable template. Exported variable template.
-</template>;
-+\\"oops\\";
-"
-`;
-
 exports[`ambiguous > config > default > +"oops" > with semi, with newline > it formats ../cases/gts/exported-mod-var-with-as.gts 1`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
-
-export interface Signature {
-  Element: HTMLElement;
-  Args: {};
-  Yields: [];
-}
-
-export const Exported = <template>
-  Exported variable template. Exported variable template. Exported variable
-  template. Exported variable template. Exported variable template. Exported
-  variable template. Exported variable template.
-</template> as TemplateOnlyComponent<Signature>;
-+\\"oops\\";
-"
-`;
-
-exports[`ambiguous > config > default > +"oops" > with semi, with newline > it formats ../cases/gts/exported-mod-var-with-as.gts 2`] = `
 "import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
 
 export interface Signature {
@@ -2098,31 +1450,7 @@ exports[`ambiguous > config > default > +"oops" > with semi, with newline > it f
 "
 `;
 
-exports[`ambiguous > config > default > +"oops" > with semi, with newline > it formats ../cases/gts/js-only.gts 2`] = `
-"const num: number = 1;
-+\\"oops\\";
-"
-`;
-
 exports[`ambiguous > config > default > +"oops" > with semi, with newline > it formats ../cases/gts/mod-var.gts 1`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
-
-export interface Signature {
-  Element: HTMLElement;
-  Args: {};
-  Yields: [];
-}
-
-const Private: TemplateOnlyComponent<Signature> = <template>
-  Private variable template. Private variable template. Private variable
-  template. Private variable template. Private variable template. Private
-  variable template. Private variable template.
-</template>;
-+\\"oops\\";
-"
-`;
-
-exports[`ambiguous > config > default > +"oops" > with semi, with newline > it formats ../cases/gts/mod-var.gts 2`] = `
 "import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
 
 export interface Signature {
@@ -2158,62 +1486,7 @@ const Private = <template>
 "
 `;
 
-exports[`ambiguous > config > default > +"oops" > with semi, with newline > it formats ../cases/gts/mod-var-with-as.gts 2`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
-
-export interface Signature {
-  Element: HTMLElement;
-  Args: {};
-  Yields: [];
-}
-
-const Private = <template>
-  Private variable template. Private variable template. Private variable
-  template. Private variable template. Private variable template. Private
-  variable template. Private variable template.
-</template> as TemplateOnlyComponent<Signature>;
-+\\"oops\\";
-"
-`;
-
 exports[`ambiguous > config > default > +"oops" > with semi, with newline > it formats ../cases/gts/multiple-declarations.gts 1`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
-
-export interface Signature {
-  Element: HTMLElement;
-  Args: {};
-  Yields: [];
-}
-
-const ModVar1: TemplateOnlyComponent<Signature> = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template>,
-  ModVar2: TemplateOnlyComponent<Signature> = <template>
-    Second module variable template.
-  </template>,
-  num = 1;
-+\\"oops\\";
-
-const bool: boolean = false,
-  ModVar3: TemplateOnlyComponent<Signature> = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template>,
-  ModVar4: TemplateOnlyComponent<Signature> = <template>
-    Second module variable template.
-  </template>;
-+\\"oops\\";
-"
-`;
-
-exports[`ambiguous > config > default > +"oops" > with semi, with newline > it formats ../cases/gts/multiple-declarations.gts 2`] = `
 "import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
 
 export interface Signature {
@@ -2287,60 +1560,7 @@ const bool: boolean = false,
 "
 `;
 
-exports[`ambiguous > config > default > +"oops" > with semi, with newline > it formats ../cases/gts/multiple-declarations-with-as.gts 2`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
-
-export interface Signature {
-  Element: HTMLElement;
-  Args: {};
-  Yields: [];
-}
-
-const ModVar1 = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template> as TemplateOnlyComponent<Signature>,
-  ModVar2 = <template>
-    Second module variable template.
-  </template> as TemplateOnlyComponent<Signature>,
-  num = 1;
-+\\"oops\\";
-
-const bool: boolean = false,
-  ModVar3 = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template> as TemplateOnlyComponent<Signature>,
-  ModVar4 = <template>
-    Second module variable template.
-  </template> as TemplateOnlyComponent<Signature>;
-+\\"oops\\";
-"
-`;
-
 exports[`ambiguous > config > default > +"oops" > with semi, with newline > it formats ../cases/gts/simple.gts 1`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
-
-export interface Signature {
-  Element: HTMLElement;
-  Args: {};
-  Yields: [];
-}
-
-<template>
-  what
-</template> as TemplateOnlyComponent<Signature>;
-+\\"oops\\";
-"
-`;
-
-exports[`ambiguous > config > default > +"oops" > with semi, with newline > it formats ../cases/gts/simple.gts 2`] = `
 "import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
 
 export interface Signature {
@@ -2647,28 +1867,7 @@ exports[`ambiguous > config > default > /oops/ > with semi, with newline > it fo
 "
 `;
 
-exports[`ambiguous > config > default > /oops/ > with semi, with newline > it formats ../cases/gjs/default-export.gjs 2`] = `
-"<template>
-  Explicit default export module top level component. Explicit default export
-  module top level component. Explicit default export module top level
-  component. Explicit default export module top level component. Explicit
-  default export module top level component.
-</template>;
-/oops/;
-"
-`;
-
 exports[`ambiguous > config > default > /oops/ > with semi, with newline > it formats ../cases/gjs/exported-mod-var.gjs 1`] = `
-"export const Exported = <template>
-  Exported variable template. Exported variable template. Exported variable
-  template. Exported variable template. Exported variable template. Exported
-  variable template. Exported variable template.
-</template>;
-/oops/;
-"
-`;
-
-exports[`ambiguous > config > default > /oops/ > with semi, with newline > it formats ../cases/gjs/exported-mod-var.gjs 2`] = `
 "export const Exported = <template>
   Exported variable template. Exported variable template. Exported variable
   template. Exported variable template. Exported variable template. Exported
@@ -2684,26 +1883,7 @@ exports[`ambiguous > config > default > /oops/ > with semi, with newline > it fo
 "
 `;
 
-exports[`ambiguous > config > default > /oops/ > with semi, with newline > it formats ../cases/gjs/js-only.gjs 2`] = `
-"const num = 1;
-/oops/;
-"
-`;
-
 exports[`ambiguous > config > default > /oops/ > with semi, with newline > it formats ../cases/gjs/mod-var.gjs 1`] = `
-"const Private = <template>
-  Private variable template. Private variable template. Private variable
-  template. Private variable template. Private variable template. Private
-  variable template. Private variable template.
-</template>;
-/oops/;
-
-const What = <template>Hi</template>;
-/oops/;
-"
-`;
-
-exports[`ambiguous > config > default > /oops/ > with semi, with newline > it formats ../cases/gjs/mod-var.gjs 2`] = `
 "const Private = <template>
   Private variable template. Private variable template. Private variable
   template. Private variable template. Private variable template. Private
@@ -2741,31 +1921,6 @@ const bool = false,
 "
 `;
 
-exports[`ambiguous > config > default > /oops/ > with semi, with newline > it formats ../cases/gjs/multiple-declarations.gjs 2`] = `
-"const ModVar1 = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template>,
-  ModVar2 = <template>Second module variable template.</template>,
-  num = 1;
-/oops/;
-
-const bool = false,
-  ModVar3 = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template>,
-  ModVar4 = <template>Second module variable template.</template>;
-/oops/;
-"
-`;
-
 exports[`ambiguous > config > default > /oops/ > with semi, with newline > it formats ../cases/gjs/simple.gjs 1`] = `
 "<template>
   what
@@ -2774,34 +1929,7 @@ exports[`ambiguous > config > default > /oops/ > with semi, with newline > it fo
 "
 `;
 
-exports[`ambiguous > config > default > /oops/ > with semi, with newline > it formats ../cases/gjs/simple.gjs 2`] = `
-"<template>
-  what
-</template>;
-/oops/;
-"
-`;
-
 exports[`ambiguous > config > default > /oops/ > with semi, with newline > it formats ../cases/gts/default-export.gts 1`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
-
-export interface Signature {
-  Element: HTMLElement;
-  Args: {};
-  Yields: [];
-}
-
-<template>
-  Explicit default export module top level component. Explicit default export
-  module top level component. Explicit default export module top level
-  component. Explicit default export module top level component. Explicit
-  default export module top level component.
-</template> as TemplateOnlyComponent<Signature>;
-/oops/;
-"
-`;
-
-exports[`ambiguous > config > default > /oops/ > with semi, with newline > it formats ../cases/gts/default-export.gts 2`] = `
 "import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
 
 export interface Signature {
@@ -2838,43 +1966,7 @@ export const Exported: TemplateOnlyComponent<Signature> = <template>
 "
 `;
 
-exports[`ambiguous > config > default > /oops/ > with semi, with newline > it formats ../cases/gts/exported-mod-var.gts 2`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
-
-export interface Signature {
-  Element: HTMLElement;
-  Args: {};
-  Yields: [];
-}
-
-export const Exported: TemplateOnlyComponent<Signature> = <template>
-  Exported variable template. Exported variable template. Exported variable
-  template. Exported variable template. Exported variable template. Exported
-  variable template. Exported variable template.
-</template>;
-/oops/;
-"
-`;
-
 exports[`ambiguous > config > default > /oops/ > with semi, with newline > it formats ../cases/gts/exported-mod-var-with-as.gts 1`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
-
-export interface Signature {
-  Element: HTMLElement;
-  Args: {};
-  Yields: [];
-}
-
-export const Exported = <template>
-  Exported variable template. Exported variable template. Exported variable
-  template. Exported variable template. Exported variable template. Exported
-  variable template. Exported variable template.
-</template> as TemplateOnlyComponent<Signature>;
-/oops/;
-"
-`;
-
-exports[`ambiguous > config > default > /oops/ > with semi, with newline > it formats ../cases/gts/exported-mod-var-with-as.gts 2`] = `
 "import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
 
 export interface Signature {
@@ -2898,31 +1990,7 @@ exports[`ambiguous > config > default > /oops/ > with semi, with newline > it fo
 "
 `;
 
-exports[`ambiguous > config > default > /oops/ > with semi, with newline > it formats ../cases/gts/js-only.gts 2`] = `
-"const num: number = 1;
-/oops/;
-"
-`;
-
 exports[`ambiguous > config > default > /oops/ > with semi, with newline > it formats ../cases/gts/mod-var.gts 1`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
-
-export interface Signature {
-  Element: HTMLElement;
-  Args: {};
-  Yields: [];
-}
-
-const Private: TemplateOnlyComponent<Signature> = <template>
-  Private variable template. Private variable template. Private variable
-  template. Private variable template. Private variable template. Private
-  variable template. Private variable template.
-</template>;
-/oops/;
-"
-`;
-
-exports[`ambiguous > config > default > /oops/ > with semi, with newline > it formats ../cases/gts/mod-var.gts 2`] = `
 "import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
 
 export interface Signature {
@@ -2958,62 +2026,7 @@ const Private = <template>
 "
 `;
 
-exports[`ambiguous > config > default > /oops/ > with semi, with newline > it formats ../cases/gts/mod-var-with-as.gts 2`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
-
-export interface Signature {
-  Element: HTMLElement;
-  Args: {};
-  Yields: [];
-}
-
-const Private = <template>
-  Private variable template. Private variable template. Private variable
-  template. Private variable template. Private variable template. Private
-  variable template. Private variable template.
-</template> as TemplateOnlyComponent<Signature>;
-/oops/;
-"
-`;
-
 exports[`ambiguous > config > default > /oops/ > with semi, with newline > it formats ../cases/gts/multiple-declarations.gts 1`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
-
-export interface Signature {
-  Element: HTMLElement;
-  Args: {};
-  Yields: [];
-}
-
-const ModVar1: TemplateOnlyComponent<Signature> = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template>,
-  ModVar2: TemplateOnlyComponent<Signature> = <template>
-    Second module variable template.
-  </template>,
-  num = 1;
-/oops/;
-
-const bool: boolean = false,
-  ModVar3: TemplateOnlyComponent<Signature> = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template>,
-  ModVar4: TemplateOnlyComponent<Signature> = <template>
-    Second module variable template.
-  </template>;
-/oops/;
-"
-`;
-
-exports[`ambiguous > config > default > /oops/ > with semi, with newline > it formats ../cases/gts/multiple-declarations.gts 2`] = `
 "import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
 
 export interface Signature {
@@ -3087,60 +2100,7 @@ const bool: boolean = false,
 "
 `;
 
-exports[`ambiguous > config > default > /oops/ > with semi, with newline > it formats ../cases/gts/multiple-declarations-with-as.gts 2`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
-
-export interface Signature {
-  Element: HTMLElement;
-  Args: {};
-  Yields: [];
-}
-
-const ModVar1 = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template> as TemplateOnlyComponent<Signature>,
-  ModVar2 = <template>
-    Second module variable template.
-  </template> as TemplateOnlyComponent<Signature>,
-  num = 1;
-/oops/;
-
-const bool: boolean = false,
-  ModVar3 = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template> as TemplateOnlyComponent<Signature>,
-  ModVar4 = <template>
-    Second module variable template.
-  </template> as TemplateOnlyComponent<Signature>;
-/oops/;
-"
-`;
-
 exports[`ambiguous > config > default > /oops/ > with semi, with newline > it formats ../cases/gts/simple.gts 1`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
-
-export interface Signature {
-  Element: HTMLElement;
-  Args: {};
-  Yields: [];
-}
-
-<template>
-  what
-</template> as TemplateOnlyComponent<Signature>;
-/oops/;
-"
-`;
-
-exports[`ambiguous > config > default > /oops/ > with semi, with newline > it formats ../cases/gts/simple.gts 2`] = `
 "import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
 
 export interface Signature {
@@ -3467,19 +2427,6 @@ exports[`ambiguous > config > default > <template>oops</template> > with semi, w
 "
 `;
 
-exports[`ambiguous > config > default > <template>oops</template> > with semi, with newline > it formats ../cases/gjs/default-export.gjs 2`] = `
-"<template>
-  Explicit default export module top level component. Explicit default export
-  module top level component. Explicit default export module top level
-  component. Explicit default export module top level component. Explicit
-  default export module top level component.
-</template>
-<template>
-  oops
-</template>
-"
-`;
-
 exports[`ambiguous > config > default > <template>oops</template> > with semi, with newline > it formats ../cases/gjs/exported-mod-var.gjs 1`] = `
 "export const Exported = <template>
   Exported variable template. Exported variable template. Exported variable
@@ -3492,27 +2439,7 @@ exports[`ambiguous > config > default > <template>oops</template> > with semi, w
 "
 `;
 
-exports[`ambiguous > config > default > <template>oops</template> > with semi, with newline > it formats ../cases/gjs/exported-mod-var.gjs 2`] = `
-"export const Exported = <template>
-  Exported variable template. Exported variable template. Exported variable
-  template. Exported variable template. Exported variable template. Exported
-  variable template. Exported variable template.
-</template>;
-<template>
-  oops
-</template>
-"
-`;
-
 exports[`ambiguous > config > default > <template>oops</template> > with semi, with newline > it formats ../cases/gjs/js-only.gjs 1`] = `
-"const num = 1;
-<template>
-  oops
-</template>
-"
-`;
-
-exports[`ambiguous > config > default > <template>oops</template> > with semi, with newline > it formats ../cases/gjs/js-only.gjs 2`] = `
 "const num = 1;
 <template>
   oops
@@ -3534,20 +2461,6 @@ const What = <template>Hi</template>;
 <template>
   oops
 </template>
-"
-`;
-
-exports[`ambiguous > config > default > <template>oops</template> > with semi, with newline > it formats ../cases/gjs/mod-var.gjs 2`] = `
-"const Private = <template>
-  Private variable template. Private variable template. Private variable
-  template. Private variable template. Private variable template. Private
-  variable template. Private variable template.
-</template>;
-<template>
-  oops
-</template>
-const What = <template>Hi</template>;
-<template>oops</template>;
 "
 `;
 
@@ -3580,45 +2493,7 @@ const bool = false,
 "
 `;
 
-exports[`ambiguous > config > default > <template>oops</template> > with semi, with newline > it formats ../cases/gjs/multiple-declarations.gjs 2`] = `
-"const ModVar1 = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template>,
-  ModVar2 = <template>Second module variable template.</template>,
-  num = 1;
-<template>
-  oops
-</template>
-const bool = false,
-  ModVar3 = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template>,
-  ModVar4 = <template>Second module variable template.</template>;
-<template>
-  oops
-</template>
-"
-`;
-
 exports[`ambiguous > config > default > <template>oops</template> > with semi, with newline > it formats ../cases/gjs/simple.gjs 1`] = `
-"<template>
-  what
-</template>
-<template>
-  oops
-</template>
-"
-`;
-
-exports[`ambiguous > config > default > <template>oops</template> > with semi, with newline > it formats ../cases/gjs/simple.gjs 2`] = `
 "<template>
   what
 </template>
@@ -3675,48 +2550,7 @@ export interface Signature {
 "
 `;
 
-exports[`ambiguous > config > default > <template>oops</template> > with semi, with newline > it formats ../cases/gts/default-export.gts 2`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
-
-export interface Signature {
-  Element: HTMLElement;
-  Args: {};
-  Yields: [];
-}
-
-<template>
-  Explicit default export module top level component. Explicit default export
-  module top level component. Explicit default export module top level
-  component. Explicit default export module top level component. Explicit
-  default export module top level component.
-</template> as TemplateOnlyComponent<Signature>
-<template>
-  oops
-</template>
-"
-`;
-
 exports[`ambiguous > config > default > <template>oops</template> > with semi, with newline > it formats ../cases/gts/exported-mod-var.gts 1`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
-
-export interface Signature {
-  Element: HTMLElement;
-  Args: {};
-  Yields: [];
-}
-
-export const Exported: TemplateOnlyComponent<Signature> = <template>
-  Exported variable template. Exported variable template. Exported variable
-  template. Exported variable template. Exported variable template. Exported
-  variable template. Exported variable template.
-</template>;
-<template>
-  oops
-</template>
-"
-`;
-
-exports[`ambiguous > config > default > <template>oops</template> > with semi, with newline > it formats ../cases/gts/exported-mod-var.gts 2`] = `
 "import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
 
 export interface Signature {
@@ -3756,35 +2590,7 @@ export const Exported = <template>
 "
 `;
 
-exports[`ambiguous > config > default > <template>oops</template> > with semi, with newline > it formats ../cases/gts/exported-mod-var-with-as.gts 2`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
-
-export interface Signature {
-  Element: HTMLElement;
-  Args: {};
-  Yields: [];
-}
-
-export const Exported = <template>
-  Exported variable template. Exported variable template. Exported variable
-  template. Exported variable template. Exported variable template. Exported
-  variable template. Exported variable template.
-</template> as TemplateOnlyComponent<Signature>;
-<template>
-  oops
-</template>
-"
-`;
-
 exports[`ambiguous > config > default > <template>oops</template> > with semi, with newline > it formats ../cases/gts/js-only.gts 1`] = `
-"const num: number = 1;
-<template>
-  oops
-</template>
-"
-`;
-
-exports[`ambiguous > config > default > <template>oops</template> > with semi, with newline > it formats ../cases/gts/js-only.gts 2`] = `
 "const num: number = 1;
 <template>
   oops
@@ -3812,47 +2618,7 @@ const Private: TemplateOnlyComponent<Signature> = <template>
 "
 `;
 
-exports[`ambiguous > config > default > <template>oops</template> > with semi, with newline > it formats ../cases/gts/mod-var.gts 2`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
-
-export interface Signature {
-  Element: HTMLElement;
-  Args: {};
-  Yields: [];
-}
-
-const Private: TemplateOnlyComponent<Signature> = <template>
-  Private variable template. Private variable template. Private variable
-  template. Private variable template. Private variable template. Private
-  variable template. Private variable template.
-</template>;
-<template>
-  oops
-</template>
-"
-`;
-
 exports[`ambiguous > config > default > <template>oops</template> > with semi, with newline > it formats ../cases/gts/mod-var-with-as.gts 1`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
-
-export interface Signature {
-  Element: HTMLElement;
-  Args: {};
-  Yields: [];
-}
-
-const Private = <template>
-  Private variable template. Private variable template. Private variable
-  template. Private variable template. Private variable template. Private
-  variable template. Private variable template.
-</template> as TemplateOnlyComponent<Signature>;
-<template>
-  oops
-</template>
-"
-`;
-
-exports[`ambiguous > config > default > <template>oops</template> > with semi, with newline > it formats ../cases/gts/mod-var-with-as.gts 2`] = `
 "import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
 
 export interface Signature {
@@ -3913,46 +2679,6 @@ const bool: boolean = false,
 "
 `;
 
-exports[`ambiguous > config > default > <template>oops</template> > with semi, with newline > it formats ../cases/gts/multiple-declarations.gts 2`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
-
-export interface Signature {
-  Element: HTMLElement;
-  Args: {};
-  Yields: [];
-}
-
-const ModVar1: TemplateOnlyComponent<Signature> = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template>,
-  ModVar2: TemplateOnlyComponent<Signature> = <template>
-    Second module variable template.
-  </template>,
-  num = 1;
-<template>
-  oops
-</template>
-const bool: boolean = false,
-  ModVar3: TemplateOnlyComponent<Signature> = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template>,
-  ModVar4: TemplateOnlyComponent<Signature> = <template>
-    Second module variable template.
-  </template>;
-<template>
-  oops
-</template>
-"
-`;
-
 exports[`ambiguous > config > default > <template>oops</template> > with semi, with newline > it formats ../cases/gts/multiple-declarations-with-as.gts 1`] = `
 "import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
 
@@ -3994,66 +2720,7 @@ const bool: boolean = false,
 "
 `;
 
-exports[`ambiguous > config > default > <template>oops</template> > with semi, with newline > it formats ../cases/gts/multiple-declarations-with-as.gts 2`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
-
-export interface Signature {
-  Element: HTMLElement;
-  Args: {};
-  Yields: [];
-}
-
-const ModVar1 = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template> as TemplateOnlyComponent<Signature>,
-  ModVar2 = <template>
-    Second module variable template.
-  </template> as TemplateOnlyComponent<Signature>,
-  num = 1;
-<template>
-  oops
-</template>
-
-const bool: boolean = false,
-  ModVar3 = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template> as TemplateOnlyComponent<Signature>,
-  ModVar4 = <template>
-    Second module variable template.
-  </template> as TemplateOnlyComponent<Signature>;
-<template>
-  oops
-</template>
-"
-`;
-
 exports[`ambiguous > config > default > <template>oops</template> > with semi, with newline > it formats ../cases/gts/simple.gts 1`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
-
-export interface Signature {
-  Element: HTMLElement;
-  Args: {};
-  Yields: [];
-}
-
-<template>
-  what
-</template> as TemplateOnlyComponent<Signature>
-<template>
-  oops
-</template>
-"
-`;
-
-exports[`ambiguous > config > default > <template>oops</template> > with semi, with newline > it formats ../cases/gts/simple.gts 2`] = `
 "import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
 
 export interface Signature {
@@ -4968,41 +3635,7 @@ class MyComponent extends Component {
 "
 `;
 
-exports[`ambiguous > config > default > ["oops"] > with semi, with newline > it formats ../cases/gjs/component-class.gjs 2`] = `
-"import Component from \\"@glimmer/component\\";
-
-/** It's a component */
-class MyComponent extends Component {
-  <template>
-    <h1>
-      Class top level template. Class top level template. Class top level
-      template. Class top level template. Class top level template.
-    </h1>
-  </template>
-  [\\"oops\\"];
-}
-"
-`;
-
 exports[`ambiguous > config > default > ["oops"] > with semi, with newline > it formats ../cases/gjs/component-class-with-content-before-template.gjs 1`] = `
-"import Component from \\"@glimmer/component\\";
-
-/** It's a component */
-class MyComponent extends Component {
-  get whatever() {}
-
-  <template>
-    <h1>
-      Class top level template. Class top level template. Class top level
-      template. Class top level template. Class top level template.
-    </h1>
-  </template>
-  [\\"oops\\"];
-}
-"
-`;
-
-exports[`ambiguous > config > default > ["oops"] > with semi, with newline > it formats ../cases/gjs/component-class-with-content-before-template.gjs 2`] = `
 "import Component from \\"@glimmer/component\\";
 
 /** It's a component */
@@ -5031,28 +3664,7 @@ exports[`ambiguous > config > default > ["oops"] > with semi, with newline > it 
 "
 `;
 
-exports[`ambiguous > config > default > ["oops"] > with semi, with newline > it formats ../cases/gjs/default-export.gjs 2`] = `
-"<template>
-  Explicit default export module top level component. Explicit default export
-  module top level component. Explicit default export module top level
-  component. Explicit default export module top level component. Explicit
-  default export module top level component.
-</template>;
-[\\"oops\\"];
-"
-`;
-
 exports[`ambiguous > config > default > ["oops"] > with semi, with newline > it formats ../cases/gjs/exported-mod-var.gjs 1`] = `
-"export const Exported = <template>
-  Exported variable template. Exported variable template. Exported variable
-  template. Exported variable template. Exported variable template. Exported
-  variable template. Exported variable template.
-</template>;
-[\\"oops\\"];
-"
-`;
-
-exports[`ambiguous > config > default > ["oops"] > with semi, with newline > it formats ../cases/gjs/exported-mod-var.gjs 2`] = `
 "export const Exported = <template>
   Exported variable template. Exported variable template. Exported variable
   template. Exported variable template. Exported variable template. Exported
@@ -5068,26 +3680,7 @@ exports[`ambiguous > config > default > ["oops"] > with semi, with newline > it 
 "
 `;
 
-exports[`ambiguous > config > default > ["oops"] > with semi, with newline > it formats ../cases/gjs/js-only.gjs 2`] = `
-"const num = 1;
-[\\"oops\\"];
-"
-`;
-
 exports[`ambiguous > config > default > ["oops"] > with semi, with newline > it formats ../cases/gjs/mod-var.gjs 1`] = `
-"const Private = <template>
-  Private variable template. Private variable template. Private variable
-  template. Private variable template. Private variable template. Private
-  variable template. Private variable template.
-</template>;
-[\\"oops\\"];
-
-const What = <template>Hi</template>;
-[\\"oops\\"];
-"
-`;
-
-exports[`ambiguous > config > default > ["oops"] > with semi, with newline > it formats ../cases/gjs/mod-var.gjs 2`] = `
 "const Private = <template>
   Private variable template. Private variable template. Private variable
   template. Private variable template. Private variable template. Private
@@ -5125,31 +3718,6 @@ const bool = false,
 "
 `;
 
-exports[`ambiguous > config > default > ["oops"] > with semi, with newline > it formats ../cases/gjs/multiple-declarations.gjs 2`] = `
-"const ModVar1 = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template>,
-  ModVar2 = <template>Second module variable template.</template>,
-  num = 1;
-[\\"oops\\"];
-
-const bool = false,
-  ModVar3 = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template>,
-  ModVar4 = <template>Second module variable template.</template>;
-[\\"oops\\"];
-"
-`;
-
 exports[`ambiguous > config > default > ["oops"] > with semi, with newline > it formats ../cases/gjs/simple.gjs 1`] = `
 "<template>
   what
@@ -5158,39 +3726,7 @@ exports[`ambiguous > config > default > ["oops"] > with semi, with newline > it 
 "
 `;
 
-exports[`ambiguous > config > default > ["oops"] > with semi, with newline > it formats ../cases/gjs/simple.gjs 2`] = `
-"<template>
-  what
-</template>;
-[\\"oops\\"];
-"
-`;
-
 exports[`ambiguous > config > default > ["oops"] > with semi, with newline > it formats ../cases/gts/component-class.gts 1`] = `
-"import Component from \\"@glimmer/component\\";
-
-export interface Signature {
-  Element: HTMLElement;
-  Args: {
-    myArg: string;
-  };
-  Yields: [];
-}
-
-/** It's a component */
-class MyComponent extends Component<Signature> {
-  <template>
-    <h1>
-      Class top level template. Class top level template. Class top level
-      template. Class top level template. Class top level template.
-    </h1>
-  </template>
-  [\\"oops\\"];
-}
-"
-`;
-
-exports[`ambiguous > config > default > ["oops"] > with semi, with newline > it formats ../cases/gts/component-class.gts 2`] = `
 "import Component from \\"@glimmer/component\\";
 
 export interface Signature {
@@ -5233,44 +3769,7 @@ export interface Signature {
 "
 `;
 
-exports[`ambiguous > config > default > ["oops"] > with semi, with newline > it formats ../cases/gts/default-export.gts 2`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
-
-export interface Signature {
-  Element: HTMLElement;
-  Args: {};
-  Yields: [];
-}
-
-<template>
-  Explicit default export module top level component. Explicit default export
-  module top level component. Explicit default export module top level
-  component. Explicit default export module top level component. Explicit
-  default export module top level component.
-</template> as TemplateOnlyComponent<Signature>;
-[\\"oops\\"];
-"
-`;
-
 exports[`ambiguous > config > default > ["oops"] > with semi, with newline > it formats ../cases/gts/exported-mod-var.gts 1`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
-
-export interface Signature {
-  Element: HTMLElement;
-  Args: {};
-  Yields: [];
-}
-
-export const Exported: TemplateOnlyComponent<Signature> = <template>
-  Exported variable template. Exported variable template. Exported variable
-  template. Exported variable template. Exported variable template. Exported
-  variable template. Exported variable template.
-</template>;
-[\\"oops\\"];
-"
-`;
-
-exports[`ambiguous > config > default > ["oops"] > with semi, with newline > it formats ../cases/gts/exported-mod-var.gts 2`] = `
 "import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
 
 export interface Signature {
@@ -5306,55 +3805,13 @@ export const Exported = <template>
 "
 `;
 
-exports[`ambiguous > config > default > ["oops"] > with semi, with newline > it formats ../cases/gts/exported-mod-var-with-as.gts 2`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
-
-export interface Signature {
-  Element: HTMLElement;
-  Args: {};
-  Yields: [];
-}
-
-export const Exported = <template>
-  Exported variable template. Exported variable template. Exported variable
-  template. Exported variable template. Exported variable template. Exported
-  variable template. Exported variable template.
-</template> as TemplateOnlyComponent<Signature>;
-[\\"oops\\"];
-"
-`;
-
 exports[`ambiguous > config > default > ["oops"] > with semi, with newline > it formats ../cases/gts/js-only.gts 1`] = `
 "const num: number = 1;
 [\\"oops\\"];
 "
 `;
 
-exports[`ambiguous > config > default > ["oops"] > with semi, with newline > it formats ../cases/gts/js-only.gts 2`] = `
-"const num: number = 1;
-[\\"oops\\"];
-"
-`;
-
 exports[`ambiguous > config > default > ["oops"] > with semi, with newline > it formats ../cases/gts/mod-var.gts 1`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
-
-export interface Signature {
-  Element: HTMLElement;
-  Args: {};
-  Yields: [];
-}
-
-const Private: TemplateOnlyComponent<Signature> = <template>
-  Private variable template. Private variable template. Private variable
-  template. Private variable template. Private variable template. Private
-  variable template. Private variable template.
-</template>;
-[\\"oops\\"];
-"
-`;
-
-exports[`ambiguous > config > default > ["oops"] > with semi, with newline > it formats ../cases/gts/mod-var.gts 2`] = `
 "import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
 
 export interface Signature {
@@ -5390,62 +3847,7 @@ const Private = <template>
 "
 `;
 
-exports[`ambiguous > config > default > ["oops"] > with semi, with newline > it formats ../cases/gts/mod-var-with-as.gts 2`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
-
-export interface Signature {
-  Element: HTMLElement;
-  Args: {};
-  Yields: [];
-}
-
-const Private = <template>
-  Private variable template. Private variable template. Private variable
-  template. Private variable template. Private variable template. Private
-  variable template. Private variable template.
-</template> as TemplateOnlyComponent<Signature>;
-[\\"oops\\"];
-"
-`;
-
 exports[`ambiguous > config > default > ["oops"] > with semi, with newline > it formats ../cases/gts/multiple-declarations.gts 1`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
-
-export interface Signature {
-  Element: HTMLElement;
-  Args: {};
-  Yields: [];
-}
-
-const ModVar1: TemplateOnlyComponent<Signature> = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template>,
-  ModVar2: TemplateOnlyComponent<Signature> = <template>
-    Second module variable template.
-  </template>,
-  num = 1;
-[\\"oops\\"];
-
-const bool: boolean = false,
-  ModVar3: TemplateOnlyComponent<Signature> = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template>,
-  ModVar4: TemplateOnlyComponent<Signature> = <template>
-    Second module variable template.
-  </template>;
-[\\"oops\\"];
-"
-`;
-
-exports[`ambiguous > config > default > ["oops"] > with semi, with newline > it formats ../cases/gts/multiple-declarations.gts 2`] = `
 "import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
 
 export interface Signature {
@@ -5519,60 +3921,7 @@ const bool: boolean = false,
 "
 `;
 
-exports[`ambiguous > config > default > ["oops"] > with semi, with newline > it formats ../cases/gts/multiple-declarations-with-as.gts 2`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
-
-export interface Signature {
-  Element: HTMLElement;
-  Args: {};
-  Yields: [];
-}
-
-const ModVar1 = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template> as TemplateOnlyComponent<Signature>,
-  ModVar2 = <template>
-    Second module variable template.
-  </template> as TemplateOnlyComponent<Signature>,
-  num = 1;
-[\\"oops\\"];
-
-const bool: boolean = false,
-  ModVar3 = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template> as TemplateOnlyComponent<Signature>,
-  ModVar4 = <template>
-    Second module variable template.
-  </template> as TemplateOnlyComponent<Signature>;
-[\\"oops\\"];
-"
-`;
-
 exports[`ambiguous > config > default > ["oops"] > with semi, with newline > it formats ../cases/gts/simple.gts 1`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
-
-export interface Signature {
-  Element: HTMLElement;
-  Args: {};
-  Yields: [];
-}
-
-<template>
-  what
-</template> as TemplateOnlyComponent<Signature>;
-[\\"oops\\"];
-"
-`;
-
-exports[`ambiguous > config > default > ["oops"] > with semi, with newline > it formats ../cases/gts/simple.gts 2`] = `
 "import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
 
 export interface Signature {
@@ -6259,28 +4608,7 @@ exports[`ambiguous > config > default > \`oops\` > with semi, with newline > it 
 "
 `;
 
-exports[`ambiguous > config > default > \`oops\` > with semi, with newline > it formats ../cases/gjs/default-export.gjs 2`] = `
-"<template>
-  Explicit default export module top level component. Explicit default export
-  module top level component. Explicit default export module top level
-  component. Explicit default export module top level component. Explicit
-  default export module top level component.
-</template>
-\`oops\`;
-"
-`;
-
 exports[`ambiguous > config > default > \`oops\` > with semi, with newline > it formats ../cases/gjs/exported-mod-var.gjs 1`] = `
-"export const Exported = <template>
-  Exported variable template. Exported variable template. Exported variable
-  template. Exported variable template. Exported variable template. Exported
-  variable template. Exported variable template.
-</template>;
-\`oops\`;
-"
-`;
-
-exports[`ambiguous > config > default > \`oops\` > with semi, with newline > it formats ../cases/gjs/exported-mod-var.gjs 2`] = `
 "export const Exported = <template>
   Exported variable template. Exported variable template. Exported variable
   template. Exported variable template. Exported variable template. Exported
@@ -6296,26 +4624,7 @@ exports[`ambiguous > config > default > \`oops\` > with semi, with newline > it 
 "
 `;
 
-exports[`ambiguous > config > default > \`oops\` > with semi, with newline > it formats ../cases/gjs/js-only.gjs 2`] = `
-"const num = 1;
-\`oops\`;
-"
-`;
-
 exports[`ambiguous > config > default > \`oops\` > with semi, with newline > it formats ../cases/gjs/mod-var.gjs 1`] = `
-"const Private = <template>
-  Private variable template. Private variable template. Private variable
-  template. Private variable template. Private variable template. Private
-  variable template. Private variable template.
-</template>;
-\`oops\`;
-
-const What = <template>Hi</template>;
-\`oops\`;
-"
-`;
-
-exports[`ambiguous > config > default > \`oops\` > with semi, with newline > it formats ../cases/gjs/mod-var.gjs 2`] = `
 "const Private = <template>
   Private variable template. Private variable template. Private variable
   template. Private variable template. Private variable template. Private
@@ -6353,31 +4662,6 @@ const bool = false,
 "
 `;
 
-exports[`ambiguous > config > default > \`oops\` > with semi, with newline > it formats ../cases/gjs/multiple-declarations.gjs 2`] = `
-"const ModVar1 = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template>,
-  ModVar2 = <template>Second module variable template.</template>,
-  num = 1;
-\`oops\`;
-
-const bool = false,
-  ModVar3 = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template>,
-  ModVar4 = <template>Second module variable template.</template>;
-\`oops\`;
-"
-`;
-
 exports[`ambiguous > config > default > \`oops\` > with semi, with newline > it formats ../cases/gjs/simple.gjs 1`] = `
 "<template>
   what
@@ -6386,34 +4670,7 @@ exports[`ambiguous > config > default > \`oops\` > with semi, with newline > it 
 "
 `;
 
-exports[`ambiguous > config > default > \`oops\` > with semi, with newline > it formats ../cases/gjs/simple.gjs 2`] = `
-"<template>
-  what
-</template>
-\`oops\`;
-"
-`;
-
 exports[`ambiguous > config > default > \`oops\` > with semi, with newline > it formats ../cases/gts/default-export.gts 1`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
-
-export interface Signature {
-  Element: HTMLElement;
-  Args: {};
-  Yields: [];
-}
-
-<template>
-  Explicit default export module top level component. Explicit default export
-  module top level component. Explicit default export module top level
-  component. Explicit default export module top level component. Explicit
-  default export module top level component.
-</template> as TemplateOnlyComponent<Signature>
-\`oops\`;
-"
-`;
-
-exports[`ambiguous > config > default > \`oops\` > with semi, with newline > it formats ../cases/gts/default-export.gts 2`] = `
 "import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
 
 export interface Signature {
@@ -6450,43 +4707,7 @@ export const Exported: TemplateOnlyComponent<Signature> = <template>
 "
 `;
 
-exports[`ambiguous > config > default > \`oops\` > with semi, with newline > it formats ../cases/gts/exported-mod-var.gts 2`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
-
-export interface Signature {
-  Element: HTMLElement;
-  Args: {};
-  Yields: [];
-}
-
-export const Exported: TemplateOnlyComponent<Signature> = <template>
-  Exported variable template. Exported variable template. Exported variable
-  template. Exported variable template. Exported variable template. Exported
-  variable template. Exported variable template.
-</template>;
-\`oops\`;
-"
-`;
-
 exports[`ambiguous > config > default > \`oops\` > with semi, with newline > it formats ../cases/gts/exported-mod-var-with-as.gts 1`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
-
-export interface Signature {
-  Element: HTMLElement;
-  Args: {};
-  Yields: [];
-}
-
-export const Exported = <template>
-  Exported variable template. Exported variable template. Exported variable
-  template. Exported variable template. Exported variable template. Exported
-  variable template. Exported variable template.
-</template> as TemplateOnlyComponent<Signature>;
-\`oops\`;
-"
-`;
-
-exports[`ambiguous > config > default > \`oops\` > with semi, with newline > it formats ../cases/gts/exported-mod-var-with-as.gts 2`] = `
 "import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
 
 export interface Signature {
@@ -6510,31 +4731,7 @@ exports[`ambiguous > config > default > \`oops\` > with semi, with newline > it 
 "
 `;
 
-exports[`ambiguous > config > default > \`oops\` > with semi, with newline > it formats ../cases/gts/js-only.gts 2`] = `
-"const num: number = 1;
-\`oops\`;
-"
-`;
-
 exports[`ambiguous > config > default > \`oops\` > with semi, with newline > it formats ../cases/gts/mod-var.gts 1`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
-
-export interface Signature {
-  Element: HTMLElement;
-  Args: {};
-  Yields: [];
-}
-
-const Private: TemplateOnlyComponent<Signature> = <template>
-  Private variable template. Private variable template. Private variable
-  template. Private variable template. Private variable template. Private
-  variable template. Private variable template.
-</template>;
-\`oops\`;
-"
-`;
-
-exports[`ambiguous > config > default > \`oops\` > with semi, with newline > it formats ../cases/gts/mod-var.gts 2`] = `
 "import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
 
 export interface Signature {
@@ -6570,62 +4767,7 @@ const Private = <template>
 "
 `;
 
-exports[`ambiguous > config > default > \`oops\` > with semi, with newline > it formats ../cases/gts/mod-var-with-as.gts 2`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
-
-export interface Signature {
-  Element: HTMLElement;
-  Args: {};
-  Yields: [];
-}
-
-const Private = <template>
-  Private variable template. Private variable template. Private variable
-  template. Private variable template. Private variable template. Private
-  variable template. Private variable template.
-</template> as TemplateOnlyComponent<Signature>;
-\`oops\`;
-"
-`;
-
 exports[`ambiguous > config > default > \`oops\` > with semi, with newline > it formats ../cases/gts/multiple-declarations.gts 1`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
-
-export interface Signature {
-  Element: HTMLElement;
-  Args: {};
-  Yields: [];
-}
-
-const ModVar1: TemplateOnlyComponent<Signature> = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template>,
-  ModVar2: TemplateOnlyComponent<Signature> = <template>
-    Second module variable template.
-  </template>,
-  num = 1;
-\`oops\`;
-
-const bool: boolean = false,
-  ModVar3: TemplateOnlyComponent<Signature> = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template>,
-  ModVar4: TemplateOnlyComponent<Signature> = <template>
-    Second module variable template.
-  </template>;
-\`oops\`;
-"
-`;
-
-exports[`ambiguous > config > default > \`oops\` > with semi, with newline > it formats ../cases/gts/multiple-declarations.gts 2`] = `
 "import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
 
 export interface Signature {
@@ -6699,60 +4841,7 @@ const bool: boolean = false,
 "
 `;
 
-exports[`ambiguous > config > default > \`oops\` > with semi, with newline > it formats ../cases/gts/multiple-declarations-with-as.gts 2`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
-
-export interface Signature {
-  Element: HTMLElement;
-  Args: {};
-  Yields: [];
-}
-
-const ModVar1 = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template> as TemplateOnlyComponent<Signature>,
-  ModVar2 = <template>
-    Second module variable template.
-  </template> as TemplateOnlyComponent<Signature>,
-  num = 1;
-\`oops\`;
-
-const bool: boolean = false,
-  ModVar3 = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template> as TemplateOnlyComponent<Signature>,
-  ModVar4 = <template>
-    Second module variable template.
-  </template> as TemplateOnlyComponent<Signature>;
-\`oops\`;
-"
-`;
-
 exports[`ambiguous > config > default > \`oops\` > with semi, with newline > it formats ../cases/gts/simple.gts 1`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
-
-export interface Signature {
-  Element: HTMLElement;
-  Args: {};
-  Yields: [];
-}
-
-<template>
-  what
-</template> as TemplateOnlyComponent<Signature>
-\`oops\`;
-"
-`;
-
-exports[`ambiguous > config > default > \`oops\` > with semi, with newline > it formats ../cases/gts/simple.gts 2`] = `
 "import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
 
 export interface Signature {
@@ -7268,28 +5357,7 @@ exports[`ambiguous > config > default > -"oops" > with semi, with newline > it f
 "
 `;
 
-exports[`ambiguous > config > default > -"oops" > with semi, with newline > it formats ../cases/gjs/default-export.gjs 2`] = `
-"<template>
-  Explicit default export module top level component. Explicit default export
-  module top level component. Explicit default export module top level
-  component. Explicit default export module top level component. Explicit
-  default export module top level component.
-</template>;
--\\"oops\\";
-"
-`;
-
 exports[`ambiguous > config > default > -"oops" > with semi, with newline > it formats ../cases/gjs/exported-mod-var.gjs 1`] = `
-"export const Exported = <template>
-  Exported variable template. Exported variable template. Exported variable
-  template. Exported variable template. Exported variable template. Exported
-  variable template. Exported variable template.
-</template>;
--\\"oops\\";
-"
-`;
-
-exports[`ambiguous > config > default > -"oops" > with semi, with newline > it formats ../cases/gjs/exported-mod-var.gjs 2`] = `
 "export const Exported = <template>
   Exported variable template. Exported variable template. Exported variable
   template. Exported variable template. Exported variable template. Exported
@@ -7305,26 +5373,7 @@ exports[`ambiguous > config > default > -"oops" > with semi, with newline > it f
 "
 `;
 
-exports[`ambiguous > config > default > -"oops" > with semi, with newline > it formats ../cases/gjs/js-only.gjs 2`] = `
-"const num = 1;
--\\"oops\\";
-"
-`;
-
 exports[`ambiguous > config > default > -"oops" > with semi, with newline > it formats ../cases/gjs/mod-var.gjs 1`] = `
-"const Private = <template>
-  Private variable template. Private variable template. Private variable
-  template. Private variable template. Private variable template. Private
-  variable template. Private variable template.
-</template>;
--\\"oops\\";
-
-const What = <template>Hi</template>;
--\\"oops\\";
-"
-`;
-
-exports[`ambiguous > config > default > -"oops" > with semi, with newline > it formats ../cases/gjs/mod-var.gjs 2`] = `
 "const Private = <template>
   Private variable template. Private variable template. Private variable
   template. Private variable template. Private variable template. Private
@@ -7362,31 +5411,6 @@ const bool = false,
 "
 `;
 
-exports[`ambiguous > config > default > -"oops" > with semi, with newline > it formats ../cases/gjs/multiple-declarations.gjs 2`] = `
-"const ModVar1 = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template>,
-  ModVar2 = <template>Second module variable template.</template>,
-  num = 1;
--\\"oops\\";
-
-const bool = false,
-  ModVar3 = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template>,
-  ModVar4 = <template>Second module variable template.</template>;
--\\"oops\\";
-"
-`;
-
 exports[`ambiguous > config > default > -"oops" > with semi, with newline > it formats ../cases/gjs/simple.gjs 1`] = `
 "<template>
   what
@@ -7395,34 +5419,7 @@ exports[`ambiguous > config > default > -"oops" > with semi, with newline > it f
 "
 `;
 
-exports[`ambiguous > config > default > -"oops" > with semi, with newline > it formats ../cases/gjs/simple.gjs 2`] = `
-"<template>
-  what
-</template>;
--\\"oops\\";
-"
-`;
-
 exports[`ambiguous > config > default > -"oops" > with semi, with newline > it formats ../cases/gts/default-export.gts 1`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
-
-export interface Signature {
-  Element: HTMLElement;
-  Args: {};
-  Yields: [];
-}
-
-<template>
-  Explicit default export module top level component. Explicit default export
-  module top level component. Explicit default export module top level
-  component. Explicit default export module top level component. Explicit
-  default export module top level component.
-</template> as TemplateOnlyComponent<Signature>;
--\\"oops\\";
-"
-`;
-
-exports[`ambiguous > config > default > -"oops" > with semi, with newline > it formats ../cases/gts/default-export.gts 2`] = `
 "import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
 
 export interface Signature {
@@ -7459,43 +5456,7 @@ export const Exported: TemplateOnlyComponent<Signature> = <template>
 "
 `;
 
-exports[`ambiguous > config > default > -"oops" > with semi, with newline > it formats ../cases/gts/exported-mod-var.gts 2`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
-
-export interface Signature {
-  Element: HTMLElement;
-  Args: {};
-  Yields: [];
-}
-
-export const Exported: TemplateOnlyComponent<Signature> = <template>
-  Exported variable template. Exported variable template. Exported variable
-  template. Exported variable template. Exported variable template. Exported
-  variable template. Exported variable template.
-</template>;
--\\"oops\\";
-"
-`;
-
 exports[`ambiguous > config > default > -"oops" > with semi, with newline > it formats ../cases/gts/exported-mod-var-with-as.gts 1`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
-
-export interface Signature {
-  Element: HTMLElement;
-  Args: {};
-  Yields: [];
-}
-
-export const Exported = <template>
-  Exported variable template. Exported variable template. Exported variable
-  template. Exported variable template. Exported variable template. Exported
-  variable template. Exported variable template.
-</template> as TemplateOnlyComponent<Signature>;
--\\"oops\\";
-"
-`;
-
-exports[`ambiguous > config > default > -"oops" > with semi, with newline > it formats ../cases/gts/exported-mod-var-with-as.gts 2`] = `
 "import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
 
 export interface Signature {
@@ -7519,31 +5480,7 @@ exports[`ambiguous > config > default > -"oops" > with semi, with newline > it f
 "
 `;
 
-exports[`ambiguous > config > default > -"oops" > with semi, with newline > it formats ../cases/gts/js-only.gts 2`] = `
-"const num: number = 1;
--\\"oops\\";
-"
-`;
-
 exports[`ambiguous > config > default > -"oops" > with semi, with newline > it formats ../cases/gts/mod-var.gts 1`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
-
-export interface Signature {
-  Element: HTMLElement;
-  Args: {};
-  Yields: [];
-}
-
-const Private: TemplateOnlyComponent<Signature> = <template>
-  Private variable template. Private variable template. Private variable
-  template. Private variable template. Private variable template. Private
-  variable template. Private variable template.
-</template>;
--\\"oops\\";
-"
-`;
-
-exports[`ambiguous > config > default > -"oops" > with semi, with newline > it formats ../cases/gts/mod-var.gts 2`] = `
 "import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
 
 export interface Signature {
@@ -7579,62 +5516,7 @@ const Private = <template>
 "
 `;
 
-exports[`ambiguous > config > default > -"oops" > with semi, with newline > it formats ../cases/gts/mod-var-with-as.gts 2`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
-
-export interface Signature {
-  Element: HTMLElement;
-  Args: {};
-  Yields: [];
-}
-
-const Private = <template>
-  Private variable template. Private variable template. Private variable
-  template. Private variable template. Private variable template. Private
-  variable template. Private variable template.
-</template> as TemplateOnlyComponent<Signature>;
--\\"oops\\";
-"
-`;
-
 exports[`ambiguous > config > default > -"oops" > with semi, with newline > it formats ../cases/gts/multiple-declarations.gts 1`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
-
-export interface Signature {
-  Element: HTMLElement;
-  Args: {};
-  Yields: [];
-}
-
-const ModVar1: TemplateOnlyComponent<Signature> = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template>,
-  ModVar2: TemplateOnlyComponent<Signature> = <template>
-    Second module variable template.
-  </template>,
-  num = 1;
--\\"oops\\";
-
-const bool: boolean = false,
-  ModVar3: TemplateOnlyComponent<Signature> = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template>,
-  ModVar4: TemplateOnlyComponent<Signature> = <template>
-    Second module variable template.
-  </template>;
--\\"oops\\";
-"
-`;
-
-exports[`ambiguous > config > default > -"oops" > with semi, with newline > it formats ../cases/gts/multiple-declarations.gts 2`] = `
 "import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
 
 export interface Signature {
@@ -7708,60 +5590,7 @@ const bool: boolean = false,
 "
 `;
 
-exports[`ambiguous > config > default > -"oops" > with semi, with newline > it formats ../cases/gts/multiple-declarations-with-as.gts 2`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
-
-export interface Signature {
-  Element: HTMLElement;
-  Args: {};
-  Yields: [];
-}
-
-const ModVar1 = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template> as TemplateOnlyComponent<Signature>,
-  ModVar2 = <template>
-    Second module variable template.
-  </template> as TemplateOnlyComponent<Signature>,
-  num = 1;
--\\"oops\\";
-
-const bool: boolean = false,
-  ModVar3 = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template> as TemplateOnlyComponent<Signature>,
-  ModVar4 = <template>
-    Second module variable template.
-  </template> as TemplateOnlyComponent<Signature>;
--\\"oops\\";
-"
-`;
-
 exports[`ambiguous > config > default > -"oops" > with semi, with newline > it formats ../cases/gts/simple.gts 1`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
-
-export interface Signature {
-  Element: HTMLElement;
-  Args: {};
-  Yields: [];
-}
-
-<template>
-  what
-</template> as TemplateOnlyComponent<Signature>;
--\\"oops\\";
-"
-`;
-
-exports[`ambiguous > config > default > -"oops" > with semi, with newline > it formats ../cases/gts/simple.gts 2`] = `
 "import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\";
 
 export interface Signature {

--- a/tests/unit-tests/ambiguous/__snapshots__/semi-false.test.ts.snap
+++ b/tests/unit-tests/ambiguous/__snapshots__/semi-false.test.ts.snap
@@ -520,6 +520,266 @@ export interface Signature {
 "
 `;
 
+exports[`ambiguous > config > semi: false > (oh, no) => {} > with semi, without newline > it formats ../cases/gjs/default-export.gjs 1`] = `
+"<template>
+  Explicit default export module top level component. Explicit default export
+  module top level component. Explicit default export module top level
+  component. Explicit default export module top level component. Explicit
+  default export module top level component.
+</template>
+;(oh, no) => {}
+"
+`;
+
+exports[`ambiguous > config > semi: false > (oh, no) => {} > with semi, without newline > it formats ../cases/gjs/exported-mod-var.gjs 1`] = `
+"export const Exported = <template>
+  Exported variable template. Exported variable template. Exported variable
+  template. Exported variable template. Exported variable template. Exported
+  variable template. Exported variable template.
+</template>
+;(oh, no) => {}
+"
+`;
+
+exports[`ambiguous > config > semi: false > (oh, no) => {} > with semi, without newline > it formats ../cases/gjs/js-only.gjs 1`] = `
+"const num = 1
+;(oh, no) => {}
+"
+`;
+
+exports[`ambiguous > config > semi: false > (oh, no) => {} > with semi, without newline > it formats ../cases/gjs/mod-var.gjs 1`] = `
+"const Private = <template>
+  Private variable template. Private variable template. Private variable
+  template. Private variable template. Private variable template. Private
+  variable template. Private variable template.
+</template>
+;(oh, no) => {}
+
+const What = <template>Hi</template>
+;(oh, no) => {}
+"
+`;
+
+exports[`ambiguous > config > semi: false > (oh, no) => {} > with semi, without newline > it formats ../cases/gjs/multiple-declarations.gjs 1`] = `
+"const ModVar1 = <template>
+    <h1>
+      Module variable template. Module variable template. Module variable
+      template. Module variable template. Module variable template. Module
+      variable template. Module variable template. Module variable template.
+    </h1>
+  </template>,
+  ModVar2 = <template>Second module variable template.</template>,
+  num = 1
+;(oh, no) => {}
+
+const bool = false,
+  ModVar3 = <template>
+    <h1>
+      Module variable template. Module variable template. Module variable
+      template. Module variable template. Module variable template. Module
+      variable template. Module variable template. Module variable template.
+    </h1>
+  </template>,
+  ModVar4 = <template>Second module variable template.</template>
+;(oh, no) => {}
+"
+`;
+
+exports[`ambiguous > config > semi: false > (oh, no) => {} > with semi, without newline > it formats ../cases/gjs/simple.gjs 1`] = `
+"<template>
+  what
+</template>
+;(oh, no) => {}
+"
+`;
+
+exports[`ambiguous > config > semi: false > (oh, no) => {} > with semi, without newline > it formats ../cases/gts/default-export.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
+
+export interface Signature {
+  Element: HTMLElement
+  Args: {}
+  Yields: []
+}
+
+<template>
+  Explicit default export module top level component. Explicit default export
+  module top level component. Explicit default export module top level
+  component. Explicit default export module top level component. Explicit
+  default export module top level component.
+</template> as TemplateOnlyComponent<Signature>
+;(oh, no) => {}
+"
+`;
+
+exports[`ambiguous > config > semi: false > (oh, no) => {} > with semi, without newline > it formats ../cases/gts/exported-mod-var.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
+
+export interface Signature {
+  Element: HTMLElement
+  Args: {}
+  Yields: []
+}
+
+export const Exported: TemplateOnlyComponent<Signature> = <template>
+  Exported variable template. Exported variable template. Exported variable
+  template. Exported variable template. Exported variable template. Exported
+  variable template. Exported variable template.
+</template>
+;(oh, no) => {}
+"
+`;
+
+exports[`ambiguous > config > semi: false > (oh, no) => {} > with semi, without newline > it formats ../cases/gts/exported-mod-var-with-as.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
+
+export interface Signature {
+  Element: HTMLElement
+  Args: {}
+  Yields: []
+}
+
+export const Exported = <template>
+  Exported variable template. Exported variable template. Exported variable
+  template. Exported variable template. Exported variable template. Exported
+  variable template. Exported variable template.
+</template> as TemplateOnlyComponent<Signature>
+;(oh, no) => {}
+"
+`;
+
+exports[`ambiguous > config > semi: false > (oh, no) => {} > with semi, without newline > it formats ../cases/gts/js-only.gts 1`] = `
+"const num: number = 1
+;(oh, no) => {}
+"
+`;
+
+exports[`ambiguous > config > semi: false > (oh, no) => {} > with semi, without newline > it formats ../cases/gts/mod-var.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
+
+export interface Signature {
+  Element: HTMLElement
+  Args: {}
+  Yields: []
+}
+
+const Private: TemplateOnlyComponent<Signature> = <template>
+  Private variable template. Private variable template. Private variable
+  template. Private variable template. Private variable template. Private
+  variable template. Private variable template.
+</template>
+;(oh, no) => {}
+"
+`;
+
+exports[`ambiguous > config > semi: false > (oh, no) => {} > with semi, without newline > it formats ../cases/gts/mod-var-with-as.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
+
+export interface Signature {
+  Element: HTMLElement
+  Args: {}
+  Yields: []
+}
+
+const Private = <template>
+  Private variable template. Private variable template. Private variable
+  template. Private variable template. Private variable template. Private
+  variable template. Private variable template.
+</template> as TemplateOnlyComponent<Signature>
+;(oh, no) => {}
+"
+`;
+
+exports[`ambiguous > config > semi: false > (oh, no) => {} > with semi, without newline > it formats ../cases/gts/multiple-declarations.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
+
+export interface Signature {
+  Element: HTMLElement
+  Args: {}
+  Yields: []
+}
+
+const ModVar1: TemplateOnlyComponent<Signature> = <template>
+    <h1>
+      Module variable template. Module variable template. Module variable
+      template. Module variable template. Module variable template. Module
+      variable template. Module variable template. Module variable template.
+    </h1>
+  </template>,
+  ModVar2: TemplateOnlyComponent<Signature> = <template>
+    Second module variable template.
+  </template>,
+  num = 1
+;(oh, no) => {}
+
+const bool: boolean = false,
+  ModVar3: TemplateOnlyComponent<Signature> = <template>
+    <h1>
+      Module variable template. Module variable template. Module variable
+      template. Module variable template. Module variable template. Module
+      variable template. Module variable template. Module variable template.
+    </h1>
+  </template>,
+  ModVar4: TemplateOnlyComponent<Signature> = <template>
+    Second module variable template.
+  </template>
+;(oh, no) => {}
+"
+`;
+
+exports[`ambiguous > config > semi: false > (oh, no) => {} > with semi, without newline > it formats ../cases/gts/multiple-declarations-with-as.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
+
+export interface Signature {
+  Element: HTMLElement
+  Args: {}
+  Yields: []
+}
+
+const ModVar1 = <template>
+    <h1>
+      Module variable template. Module variable template. Module variable
+      template. Module variable template. Module variable template. Module
+      variable template. Module variable template. Module variable template.
+    </h1>
+  </template> as TemplateOnlyComponent<Signature>,
+  ModVar2 = <template>
+    Second module variable template.
+  </template> as TemplateOnlyComponent<Signature>,
+  num = 1
+;(oh, no) => {}
+
+const bool: boolean = false,
+  ModVar3 = <template>
+    <h1>
+      Module variable template. Module variable template. Module variable
+      template. Module variable template. Module variable template. Module
+      variable template. Module variable template. Module variable template.
+    </h1>
+  </template> as TemplateOnlyComponent<Signature>,
+  ModVar4 = <template>
+    Second module variable template.
+  </template> as TemplateOnlyComponent<Signature>
+;(oh, no) => {}
+"
+`;
+
+exports[`ambiguous > config > semi: false > (oh, no) => {} > with semi, without newline > it formats ../cases/gts/simple.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
+
+export interface Signature {
+  Element: HTMLElement
+  Args: {}
+  Yields: []
+}
+
+<template>
+  what
+</template> as TemplateOnlyComponent<Signature>
+;(oh, no) => {}
+"
+`;
+
 exports[`ambiguous > config > semi: false > (oh, no) => {} > without semi, with newline > it formats ../cases/gts/default-export.gts 1`] = `
 "import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
 
@@ -1163,6 +1423,266 @@ export interface Signature {
 `;
 
 exports[`ambiguous > config > semi: false > (oops) => {} > with semi, with newline > it formats ../cases/gts/simple.gts 2`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
+
+export interface Signature {
+  Element: HTMLElement
+  Args: {}
+  Yields: []
+}
+
+<template>
+  what
+</template> as TemplateOnlyComponent<Signature>
+;(oops) => {}
+"
+`;
+
+exports[`ambiguous > config > semi: false > (oops) => {} > with semi, without newline > it formats ../cases/gjs/default-export.gjs 1`] = `
+"<template>
+  Explicit default export module top level component. Explicit default export
+  module top level component. Explicit default export module top level
+  component. Explicit default export module top level component. Explicit
+  default export module top level component.
+</template>
+;(oops) => {}
+"
+`;
+
+exports[`ambiguous > config > semi: false > (oops) => {} > with semi, without newline > it formats ../cases/gjs/exported-mod-var.gjs 1`] = `
+"export const Exported = <template>
+  Exported variable template. Exported variable template. Exported variable
+  template. Exported variable template. Exported variable template. Exported
+  variable template. Exported variable template.
+</template>
+;(oops) => {}
+"
+`;
+
+exports[`ambiguous > config > semi: false > (oops) => {} > with semi, without newline > it formats ../cases/gjs/js-only.gjs 1`] = `
+"const num = 1
+;(oops) => {}
+"
+`;
+
+exports[`ambiguous > config > semi: false > (oops) => {} > with semi, without newline > it formats ../cases/gjs/mod-var.gjs 1`] = `
+"const Private = <template>
+  Private variable template. Private variable template. Private variable
+  template. Private variable template. Private variable template. Private
+  variable template. Private variable template.
+</template>
+;(oops) => {}
+
+const What = <template>Hi</template>
+;(oops) => {}
+"
+`;
+
+exports[`ambiguous > config > semi: false > (oops) => {} > with semi, without newline > it formats ../cases/gjs/multiple-declarations.gjs 1`] = `
+"const ModVar1 = <template>
+    <h1>
+      Module variable template. Module variable template. Module variable
+      template. Module variable template. Module variable template. Module
+      variable template. Module variable template. Module variable template.
+    </h1>
+  </template>,
+  ModVar2 = <template>Second module variable template.</template>,
+  num = 1
+;(oops) => {}
+
+const bool = false,
+  ModVar3 = <template>
+    <h1>
+      Module variable template. Module variable template. Module variable
+      template. Module variable template. Module variable template. Module
+      variable template. Module variable template. Module variable template.
+    </h1>
+  </template>,
+  ModVar4 = <template>Second module variable template.</template>
+;(oops) => {}
+"
+`;
+
+exports[`ambiguous > config > semi: false > (oops) => {} > with semi, without newline > it formats ../cases/gjs/simple.gjs 1`] = `
+"<template>
+  what
+</template>
+;(oops) => {}
+"
+`;
+
+exports[`ambiguous > config > semi: false > (oops) => {} > with semi, without newline > it formats ../cases/gts/default-export.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
+
+export interface Signature {
+  Element: HTMLElement
+  Args: {}
+  Yields: []
+}
+
+<template>
+  Explicit default export module top level component. Explicit default export
+  module top level component. Explicit default export module top level
+  component. Explicit default export module top level component. Explicit
+  default export module top level component.
+</template> as TemplateOnlyComponent<Signature>
+;(oops) => {}
+"
+`;
+
+exports[`ambiguous > config > semi: false > (oops) => {} > with semi, without newline > it formats ../cases/gts/exported-mod-var.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
+
+export interface Signature {
+  Element: HTMLElement
+  Args: {}
+  Yields: []
+}
+
+export const Exported: TemplateOnlyComponent<Signature> = <template>
+  Exported variable template. Exported variable template. Exported variable
+  template. Exported variable template. Exported variable template. Exported
+  variable template. Exported variable template.
+</template>
+;(oops) => {}
+"
+`;
+
+exports[`ambiguous > config > semi: false > (oops) => {} > with semi, without newline > it formats ../cases/gts/exported-mod-var-with-as.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
+
+export interface Signature {
+  Element: HTMLElement
+  Args: {}
+  Yields: []
+}
+
+export const Exported = <template>
+  Exported variable template. Exported variable template. Exported variable
+  template. Exported variable template. Exported variable template. Exported
+  variable template. Exported variable template.
+</template> as TemplateOnlyComponent<Signature>
+;(oops) => {}
+"
+`;
+
+exports[`ambiguous > config > semi: false > (oops) => {} > with semi, without newline > it formats ../cases/gts/js-only.gts 1`] = `
+"const num: number = 1
+;(oops) => {}
+"
+`;
+
+exports[`ambiguous > config > semi: false > (oops) => {} > with semi, without newline > it formats ../cases/gts/mod-var.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
+
+export interface Signature {
+  Element: HTMLElement
+  Args: {}
+  Yields: []
+}
+
+const Private: TemplateOnlyComponent<Signature> = <template>
+  Private variable template. Private variable template. Private variable
+  template. Private variable template. Private variable template. Private
+  variable template. Private variable template.
+</template>
+;(oops) => {}
+"
+`;
+
+exports[`ambiguous > config > semi: false > (oops) => {} > with semi, without newline > it formats ../cases/gts/mod-var-with-as.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
+
+export interface Signature {
+  Element: HTMLElement
+  Args: {}
+  Yields: []
+}
+
+const Private = <template>
+  Private variable template. Private variable template. Private variable
+  template. Private variable template. Private variable template. Private
+  variable template. Private variable template.
+</template> as TemplateOnlyComponent<Signature>
+;(oops) => {}
+"
+`;
+
+exports[`ambiguous > config > semi: false > (oops) => {} > with semi, without newline > it formats ../cases/gts/multiple-declarations.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
+
+export interface Signature {
+  Element: HTMLElement
+  Args: {}
+  Yields: []
+}
+
+const ModVar1: TemplateOnlyComponent<Signature> = <template>
+    <h1>
+      Module variable template. Module variable template. Module variable
+      template. Module variable template. Module variable template. Module
+      variable template. Module variable template. Module variable template.
+    </h1>
+  </template>,
+  ModVar2: TemplateOnlyComponent<Signature> = <template>
+    Second module variable template.
+  </template>,
+  num = 1
+;(oops) => {}
+
+const bool: boolean = false,
+  ModVar3: TemplateOnlyComponent<Signature> = <template>
+    <h1>
+      Module variable template. Module variable template. Module variable
+      template. Module variable template. Module variable template. Module
+      variable template. Module variable template. Module variable template.
+    </h1>
+  </template>,
+  ModVar4: TemplateOnlyComponent<Signature> = <template>
+    Second module variable template.
+  </template>
+;(oops) => {}
+"
+`;
+
+exports[`ambiguous > config > semi: false > (oops) => {} > with semi, without newline > it formats ../cases/gts/multiple-declarations-with-as.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
+
+export interface Signature {
+  Element: HTMLElement
+  Args: {}
+  Yields: []
+}
+
+const ModVar1 = <template>
+    <h1>
+      Module variable template. Module variable template. Module variable
+      template. Module variable template. Module variable template. Module
+      variable template. Module variable template. Module variable template.
+    </h1>
+  </template> as TemplateOnlyComponent<Signature>,
+  ModVar2 = <template>
+    Second module variable template.
+  </template> as TemplateOnlyComponent<Signature>,
+  num = 1
+;(oops) => {}
+
+const bool: boolean = false,
+  ModVar3 = <template>
+    <h1>
+      Module variable template. Module variable template. Module variable
+      template. Module variable template. Module variable template. Module
+      variable template. Module variable template. Module variable template.
+    </h1>
+  </template> as TemplateOnlyComponent<Signature>,
+  ModVar4 = <template>
+    Second module variable template.
+  </template> as TemplateOnlyComponent<Signature>
+;(oops) => {}
+"
+`;
+
+exports[`ambiguous > config > semi: false > (oops) => {} > with semi, without newline > it formats ../cases/gts/simple.gts 1`] = `
 "import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
 
 export interface Signature {
@@ -1836,6 +2356,266 @@ export interface Signature {
 "
 `;
 
+exports[`ambiguous > config > semi: false > +"oops" > with semi, without newline > it formats ../cases/gjs/default-export.gjs 1`] = `
+"<template>
+  Explicit default export module top level component. Explicit default export
+  module top level component. Explicit default export module top level
+  component. Explicit default export module top level component. Explicit
+  default export module top level component.
+</template>
+;+\\"oops\\"
+"
+`;
+
+exports[`ambiguous > config > semi: false > +"oops" > with semi, without newline > it formats ../cases/gjs/exported-mod-var.gjs 1`] = `
+"export const Exported = <template>
+  Exported variable template. Exported variable template. Exported variable
+  template. Exported variable template. Exported variable template. Exported
+  variable template. Exported variable template.
+</template>
+;+\\"oops\\"
+"
+`;
+
+exports[`ambiguous > config > semi: false > +"oops" > with semi, without newline > it formats ../cases/gjs/js-only.gjs 1`] = `
+"const num = 1
+;+\\"oops\\"
+"
+`;
+
+exports[`ambiguous > config > semi: false > +"oops" > with semi, without newline > it formats ../cases/gjs/mod-var.gjs 1`] = `
+"const Private = <template>
+  Private variable template. Private variable template. Private variable
+  template. Private variable template. Private variable template. Private
+  variable template. Private variable template.
+</template>
+;+\\"oops\\"
+
+const What = <template>Hi</template>
+;+\\"oops\\"
+"
+`;
+
+exports[`ambiguous > config > semi: false > +"oops" > with semi, without newline > it formats ../cases/gjs/multiple-declarations.gjs 1`] = `
+"const ModVar1 = <template>
+    <h1>
+      Module variable template. Module variable template. Module variable
+      template. Module variable template. Module variable template. Module
+      variable template. Module variable template. Module variable template.
+    </h1>
+  </template>,
+  ModVar2 = <template>Second module variable template.</template>,
+  num = 1
+;+\\"oops\\"
+
+const bool = false,
+  ModVar3 = <template>
+    <h1>
+      Module variable template. Module variable template. Module variable
+      template. Module variable template. Module variable template. Module
+      variable template. Module variable template. Module variable template.
+    </h1>
+  </template>,
+  ModVar4 = <template>Second module variable template.</template>
+;+\\"oops\\"
+"
+`;
+
+exports[`ambiguous > config > semi: false > +"oops" > with semi, without newline > it formats ../cases/gjs/simple.gjs 1`] = `
+"<template>
+  what
+</template>
+;+\\"oops\\"
+"
+`;
+
+exports[`ambiguous > config > semi: false > +"oops" > with semi, without newline > it formats ../cases/gts/default-export.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
+
+export interface Signature {
+  Element: HTMLElement
+  Args: {}
+  Yields: []
+}
+
+<template>
+  Explicit default export module top level component. Explicit default export
+  module top level component. Explicit default export module top level
+  component. Explicit default export module top level component. Explicit
+  default export module top level component.
+</template> as TemplateOnlyComponent<Signature>
+;+\\"oops\\"
+"
+`;
+
+exports[`ambiguous > config > semi: false > +"oops" > with semi, without newline > it formats ../cases/gts/exported-mod-var.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
+
+export interface Signature {
+  Element: HTMLElement
+  Args: {}
+  Yields: []
+}
+
+export const Exported: TemplateOnlyComponent<Signature> = <template>
+  Exported variable template. Exported variable template. Exported variable
+  template. Exported variable template. Exported variable template. Exported
+  variable template. Exported variable template.
+</template>
+;+\\"oops\\"
+"
+`;
+
+exports[`ambiguous > config > semi: false > +"oops" > with semi, without newline > it formats ../cases/gts/exported-mod-var-with-as.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
+
+export interface Signature {
+  Element: HTMLElement
+  Args: {}
+  Yields: []
+}
+
+export const Exported = <template>
+  Exported variable template. Exported variable template. Exported variable
+  template. Exported variable template. Exported variable template. Exported
+  variable template. Exported variable template.
+</template> as TemplateOnlyComponent<Signature>
+;+\\"oops\\"
+"
+`;
+
+exports[`ambiguous > config > semi: false > +"oops" > with semi, without newline > it formats ../cases/gts/js-only.gts 1`] = `
+"const num: number = 1
+;+\\"oops\\"
+"
+`;
+
+exports[`ambiguous > config > semi: false > +"oops" > with semi, without newline > it formats ../cases/gts/mod-var.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
+
+export interface Signature {
+  Element: HTMLElement
+  Args: {}
+  Yields: []
+}
+
+const Private: TemplateOnlyComponent<Signature> = <template>
+  Private variable template. Private variable template. Private variable
+  template. Private variable template. Private variable template. Private
+  variable template. Private variable template.
+</template>
+;+\\"oops\\"
+"
+`;
+
+exports[`ambiguous > config > semi: false > +"oops" > with semi, without newline > it formats ../cases/gts/mod-var-with-as.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
+
+export interface Signature {
+  Element: HTMLElement
+  Args: {}
+  Yields: []
+}
+
+const Private = <template>
+  Private variable template. Private variable template. Private variable
+  template. Private variable template. Private variable template. Private
+  variable template. Private variable template.
+</template> as TemplateOnlyComponent<Signature>
+;+\\"oops\\"
+"
+`;
+
+exports[`ambiguous > config > semi: false > +"oops" > with semi, without newline > it formats ../cases/gts/multiple-declarations.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
+
+export interface Signature {
+  Element: HTMLElement
+  Args: {}
+  Yields: []
+}
+
+const ModVar1: TemplateOnlyComponent<Signature> = <template>
+    <h1>
+      Module variable template. Module variable template. Module variable
+      template. Module variable template. Module variable template. Module
+      variable template. Module variable template. Module variable template.
+    </h1>
+  </template>,
+  ModVar2: TemplateOnlyComponent<Signature> = <template>
+    Second module variable template.
+  </template>,
+  num = 1
+;+\\"oops\\"
+
+const bool: boolean = false,
+  ModVar3: TemplateOnlyComponent<Signature> = <template>
+    <h1>
+      Module variable template. Module variable template. Module variable
+      template. Module variable template. Module variable template. Module
+      variable template. Module variable template. Module variable template.
+    </h1>
+  </template>,
+  ModVar4: TemplateOnlyComponent<Signature> = <template>
+    Second module variable template.
+  </template>
+;+\\"oops\\"
+"
+`;
+
+exports[`ambiguous > config > semi: false > +"oops" > with semi, without newline > it formats ../cases/gts/multiple-declarations-with-as.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
+
+export interface Signature {
+  Element: HTMLElement
+  Args: {}
+  Yields: []
+}
+
+const ModVar1 = <template>
+    <h1>
+      Module variable template. Module variable template. Module variable
+      template. Module variable template. Module variable template. Module
+      variable template. Module variable template. Module variable template.
+    </h1>
+  </template> as TemplateOnlyComponent<Signature>,
+  ModVar2 = <template>
+    Second module variable template.
+  </template> as TemplateOnlyComponent<Signature>,
+  num = 1
+;+\\"oops\\"
+
+const bool: boolean = false,
+  ModVar3 = <template>
+    <h1>
+      Module variable template. Module variable template. Module variable
+      template. Module variable template. Module variable template. Module
+      variable template. Module variable template. Module variable template.
+    </h1>
+  </template> as TemplateOnlyComponent<Signature>,
+  ModVar4 = <template>
+    Second module variable template.
+  </template> as TemplateOnlyComponent<Signature>
+;+\\"oops\\"
+"
+`;
+
+exports[`ambiguous > config > semi: false > +"oops" > with semi, without newline > it formats ../cases/gts/simple.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
+
+export interface Signature {
+  Element: HTMLElement
+  Args: {}
+  Yields: []
+}
+
+<template>
+  what
+</template> as TemplateOnlyComponent<Signature>
+;+\\"oops\\"
+"
+`;
+
 exports[`ambiguous > config > semi: false > +"oops" > without semi, with newline > it formats ../cases/gjs/js-only.gjs 1`] = `
 "const num = 1 + \\"oops\\"
 "
@@ -2361,6 +3141,266 @@ export interface Signature {
 `;
 
 exports[`ambiguous > config > semi: false > /oops/ > with semi, with newline > it formats ../cases/gts/simple.gts 2`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
+
+export interface Signature {
+  Element: HTMLElement
+  Args: {}
+  Yields: []
+}
+
+<template>
+  what
+</template> as TemplateOnlyComponent<Signature>
+;/oops/
+"
+`;
+
+exports[`ambiguous > config > semi: false > /oops/ > with semi, without newline > it formats ../cases/gjs/default-export.gjs 1`] = `
+"<template>
+  Explicit default export module top level component. Explicit default export
+  module top level component. Explicit default export module top level
+  component. Explicit default export module top level component. Explicit
+  default export module top level component.
+</template>
+;/oops/
+"
+`;
+
+exports[`ambiguous > config > semi: false > /oops/ > with semi, without newline > it formats ../cases/gjs/exported-mod-var.gjs 1`] = `
+"export const Exported = <template>
+  Exported variable template. Exported variable template. Exported variable
+  template. Exported variable template. Exported variable template. Exported
+  variable template. Exported variable template.
+</template>
+;/oops/
+"
+`;
+
+exports[`ambiguous > config > semi: false > /oops/ > with semi, without newline > it formats ../cases/gjs/js-only.gjs 1`] = `
+"const num = 1
+;/oops/
+"
+`;
+
+exports[`ambiguous > config > semi: false > /oops/ > with semi, without newline > it formats ../cases/gjs/mod-var.gjs 1`] = `
+"const Private = <template>
+  Private variable template. Private variable template. Private variable
+  template. Private variable template. Private variable template. Private
+  variable template. Private variable template.
+</template>
+;/oops/
+
+const What = <template>Hi</template>
+;/oops/
+"
+`;
+
+exports[`ambiguous > config > semi: false > /oops/ > with semi, without newline > it formats ../cases/gjs/multiple-declarations.gjs 1`] = `
+"const ModVar1 = <template>
+    <h1>
+      Module variable template. Module variable template. Module variable
+      template. Module variable template. Module variable template. Module
+      variable template. Module variable template. Module variable template.
+    </h1>
+  </template>,
+  ModVar2 = <template>Second module variable template.</template>,
+  num = 1
+;/oops/
+
+const bool = false,
+  ModVar3 = <template>
+    <h1>
+      Module variable template. Module variable template. Module variable
+      template. Module variable template. Module variable template. Module
+      variable template. Module variable template. Module variable template.
+    </h1>
+  </template>,
+  ModVar4 = <template>Second module variable template.</template>
+;/oops/
+"
+`;
+
+exports[`ambiguous > config > semi: false > /oops/ > with semi, without newline > it formats ../cases/gjs/simple.gjs 1`] = `
+"<template>
+  what
+</template>
+;/oops/
+"
+`;
+
+exports[`ambiguous > config > semi: false > /oops/ > with semi, without newline > it formats ../cases/gts/default-export.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
+
+export interface Signature {
+  Element: HTMLElement
+  Args: {}
+  Yields: []
+}
+
+<template>
+  Explicit default export module top level component. Explicit default export
+  module top level component. Explicit default export module top level
+  component. Explicit default export module top level component. Explicit
+  default export module top level component.
+</template> as TemplateOnlyComponent<Signature>
+;/oops/
+"
+`;
+
+exports[`ambiguous > config > semi: false > /oops/ > with semi, without newline > it formats ../cases/gts/exported-mod-var.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
+
+export interface Signature {
+  Element: HTMLElement
+  Args: {}
+  Yields: []
+}
+
+export const Exported: TemplateOnlyComponent<Signature> = <template>
+  Exported variable template. Exported variable template. Exported variable
+  template. Exported variable template. Exported variable template. Exported
+  variable template. Exported variable template.
+</template>
+;/oops/
+"
+`;
+
+exports[`ambiguous > config > semi: false > /oops/ > with semi, without newline > it formats ../cases/gts/exported-mod-var-with-as.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
+
+export interface Signature {
+  Element: HTMLElement
+  Args: {}
+  Yields: []
+}
+
+export const Exported = <template>
+  Exported variable template. Exported variable template. Exported variable
+  template. Exported variable template. Exported variable template. Exported
+  variable template. Exported variable template.
+</template> as TemplateOnlyComponent<Signature>
+;/oops/
+"
+`;
+
+exports[`ambiguous > config > semi: false > /oops/ > with semi, without newline > it formats ../cases/gts/js-only.gts 1`] = `
+"const num: number = 1
+;/oops/
+"
+`;
+
+exports[`ambiguous > config > semi: false > /oops/ > with semi, without newline > it formats ../cases/gts/mod-var.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
+
+export interface Signature {
+  Element: HTMLElement
+  Args: {}
+  Yields: []
+}
+
+const Private: TemplateOnlyComponent<Signature> = <template>
+  Private variable template. Private variable template. Private variable
+  template. Private variable template. Private variable template. Private
+  variable template. Private variable template.
+</template>
+;/oops/
+"
+`;
+
+exports[`ambiguous > config > semi: false > /oops/ > with semi, without newline > it formats ../cases/gts/mod-var-with-as.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
+
+export interface Signature {
+  Element: HTMLElement
+  Args: {}
+  Yields: []
+}
+
+const Private = <template>
+  Private variable template. Private variable template. Private variable
+  template. Private variable template. Private variable template. Private
+  variable template. Private variable template.
+</template> as TemplateOnlyComponent<Signature>
+;/oops/
+"
+`;
+
+exports[`ambiguous > config > semi: false > /oops/ > with semi, without newline > it formats ../cases/gts/multiple-declarations.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
+
+export interface Signature {
+  Element: HTMLElement
+  Args: {}
+  Yields: []
+}
+
+const ModVar1: TemplateOnlyComponent<Signature> = <template>
+    <h1>
+      Module variable template. Module variable template. Module variable
+      template. Module variable template. Module variable template. Module
+      variable template. Module variable template. Module variable template.
+    </h1>
+  </template>,
+  ModVar2: TemplateOnlyComponent<Signature> = <template>
+    Second module variable template.
+  </template>,
+  num = 1
+;/oops/
+
+const bool: boolean = false,
+  ModVar3: TemplateOnlyComponent<Signature> = <template>
+    <h1>
+      Module variable template. Module variable template. Module variable
+      template. Module variable template. Module variable template. Module
+      variable template. Module variable template. Module variable template.
+    </h1>
+  </template>,
+  ModVar4: TemplateOnlyComponent<Signature> = <template>
+    Second module variable template.
+  </template>
+;/oops/
+"
+`;
+
+exports[`ambiguous > config > semi: false > /oops/ > with semi, without newline > it formats ../cases/gts/multiple-declarations-with-as.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
+
+export interface Signature {
+  Element: HTMLElement
+  Args: {}
+  Yields: []
+}
+
+const ModVar1 = <template>
+    <h1>
+      Module variable template. Module variable template. Module variable
+      template. Module variable template. Module variable template. Module
+      variable template. Module variable template. Module variable template.
+    </h1>
+  </template> as TemplateOnlyComponent<Signature>,
+  ModVar2 = <template>
+    Second module variable template.
+  </template> as TemplateOnlyComponent<Signature>,
+  num = 1
+;/oops/
+
+const bool: boolean = false,
+  ModVar3 = <template>
+    <h1>
+      Module variable template. Module variable template. Module variable
+      template. Module variable template. Module variable template. Module
+      variable template. Module variable template. Module variable template.
+    </h1>
+  </template> as TemplateOnlyComponent<Signature>,
+  ModVar4 = <template>
+    Second module variable template.
+  </template> as TemplateOnlyComponent<Signature>
+;/oops/
+"
+`;
+
+exports[`ambiguous > config > semi: false > /oops/ > with semi, without newline > it formats ../cases/gts/simple.gts 1`] = `
 "import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
 
 export interface Signature {
@@ -3014,6 +4054,299 @@ export interface Signature {
 `;
 
 exports[`ambiguous > config > semi: false > <template>oops</template> > with semi, with newline > it formats ../cases/gts/simple.gts 2`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
+
+export interface Signature {
+  Element: HTMLElement
+  Args: {}
+  Yields: []
+}
+
+<template>
+  what
+</template> as TemplateOnlyComponent<Signature>
+<template>
+  oops
+</template>
+"
+`;
+
+exports[`ambiguous > config > semi: false > <template>oops</template> > with semi, without newline > it formats ../cases/gjs/default-export.gjs 1`] = `
+"<template>
+  Explicit default export module top level component. Explicit default export
+  module top level component. Explicit default export module top level
+  component. Explicit default export module top level component. Explicit
+  default export module top level component.
+</template>
+<template>
+  oops
+</template>
+"
+`;
+
+exports[`ambiguous > config > semi: false > <template>oops</template> > with semi, without newline > it formats ../cases/gjs/exported-mod-var.gjs 1`] = `
+"export const Exported = <template>
+  Exported variable template. Exported variable template. Exported variable
+  template. Exported variable template. Exported variable template. Exported
+  variable template. Exported variable template.
+</template>
+<template>
+  oops
+</template>
+"
+`;
+
+exports[`ambiguous > config > semi: false > <template>oops</template> > with semi, without newline > it formats ../cases/gjs/js-only.gjs 1`] = `
+"const num = 1
+<template>
+  oops
+</template>
+"
+`;
+
+exports[`ambiguous > config > semi: false > <template>oops</template> > with semi, without newline > it formats ../cases/gjs/mod-var.gjs 1`] = `
+"const Private = <template>
+  Private variable template. Private variable template. Private variable
+  template. Private variable template. Private variable template. Private
+  variable template. Private variable template.
+</template>
+<template>
+  oops
+</template>
+const What = <template>Hi</template>
+<template>oops</template>
+"
+`;
+
+exports[`ambiguous > config > semi: false > <template>oops</template> > with semi, without newline > it formats ../cases/gjs/multiple-declarations.gjs 1`] = `
+"const ModVar1 = <template>
+    <h1>
+      Module variable template. Module variable template. Module variable
+      template. Module variable template. Module variable template. Module
+      variable template. Module variable template. Module variable template.
+    </h1>
+  </template>,
+  ModVar2 = <template>Second module variable template.</template>,
+  num = 1
+<template>
+  oops
+</template>
+const bool = false,
+  ModVar3 = <template>
+    <h1>
+      Module variable template. Module variable template. Module variable
+      template. Module variable template. Module variable template. Module
+      variable template. Module variable template. Module variable template.
+    </h1>
+  </template>,
+  ModVar4 = <template>Second module variable template.</template>
+<template>
+  oops
+</template>
+"
+`;
+
+exports[`ambiguous > config > semi: false > <template>oops</template> > with semi, without newline > it formats ../cases/gjs/simple.gjs 1`] = `
+"<template>
+  what
+</template>
+<template>
+  oops
+</template>
+"
+`;
+
+exports[`ambiguous > config > semi: false > <template>oops</template> > with semi, without newline > it formats ../cases/gts/default-export.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
+
+export interface Signature {
+  Element: HTMLElement
+  Args: {}
+  Yields: []
+}
+
+<template>
+  Explicit default export module top level component. Explicit default export
+  module top level component. Explicit default export module top level
+  component. Explicit default export module top level component. Explicit
+  default export module top level component.
+</template> as TemplateOnlyComponent<Signature>
+<template>
+  oops
+</template>
+"
+`;
+
+exports[`ambiguous > config > semi: false > <template>oops</template> > with semi, without newline > it formats ../cases/gts/exported-mod-var.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
+
+export interface Signature {
+  Element: HTMLElement
+  Args: {}
+  Yields: []
+}
+
+export const Exported: TemplateOnlyComponent<Signature> = <template>
+  Exported variable template. Exported variable template. Exported variable
+  template. Exported variable template. Exported variable template. Exported
+  variable template. Exported variable template.
+</template>
+<template>
+  oops
+</template>
+"
+`;
+
+exports[`ambiguous > config > semi: false > <template>oops</template> > with semi, without newline > it formats ../cases/gts/exported-mod-var-with-as.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
+
+export interface Signature {
+  Element: HTMLElement
+  Args: {}
+  Yields: []
+}
+
+export const Exported = <template>
+  Exported variable template. Exported variable template. Exported variable
+  template. Exported variable template. Exported variable template. Exported
+  variable template. Exported variable template.
+</template> as TemplateOnlyComponent<Signature>
+<template>
+  oops
+</template>
+"
+`;
+
+exports[`ambiguous > config > semi: false > <template>oops</template> > with semi, without newline > it formats ../cases/gts/js-only.gts 1`] = `
+"const num: number = 1
+<template>
+  oops
+</template>
+"
+`;
+
+exports[`ambiguous > config > semi: false > <template>oops</template> > with semi, without newline > it formats ../cases/gts/mod-var.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
+
+export interface Signature {
+  Element: HTMLElement
+  Args: {}
+  Yields: []
+}
+
+const Private: TemplateOnlyComponent<Signature> = <template>
+  Private variable template. Private variable template. Private variable
+  template. Private variable template. Private variable template. Private
+  variable template. Private variable template.
+</template>
+<template>
+  oops
+</template>
+"
+`;
+
+exports[`ambiguous > config > semi: false > <template>oops</template> > with semi, without newline > it formats ../cases/gts/mod-var-with-as.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
+
+export interface Signature {
+  Element: HTMLElement
+  Args: {}
+  Yields: []
+}
+
+const Private = <template>
+  Private variable template. Private variable template. Private variable
+  template. Private variable template. Private variable template. Private
+  variable template. Private variable template.
+</template> as TemplateOnlyComponent<Signature>
+<template>
+  oops
+</template>
+"
+`;
+
+exports[`ambiguous > config > semi: false > <template>oops</template> > with semi, without newline > it formats ../cases/gts/multiple-declarations.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
+
+export interface Signature {
+  Element: HTMLElement
+  Args: {}
+  Yields: []
+}
+
+const ModVar1: TemplateOnlyComponent<Signature> = <template>
+    <h1>
+      Module variable template. Module variable template. Module variable
+      template. Module variable template. Module variable template. Module
+      variable template. Module variable template. Module variable template.
+    </h1>
+  </template>,
+  ModVar2: TemplateOnlyComponent<Signature> = <template>
+    Second module variable template.
+  </template>,
+  num = 1
+<template>
+  oops
+</template>
+const bool: boolean = false,
+  ModVar3: TemplateOnlyComponent<Signature> = <template>
+    <h1>
+      Module variable template. Module variable template. Module variable
+      template. Module variable template. Module variable template. Module
+      variable template. Module variable template. Module variable template.
+    </h1>
+  </template>,
+  ModVar4: TemplateOnlyComponent<Signature> = <template>
+    Second module variable template.
+  </template>
+<template>
+  oops
+</template>
+"
+`;
+
+exports[`ambiguous > config > semi: false > <template>oops</template> > with semi, without newline > it formats ../cases/gts/multiple-declarations-with-as.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
+
+export interface Signature {
+  Element: HTMLElement
+  Args: {}
+  Yields: []
+}
+
+const ModVar1 = <template>
+    <h1>
+      Module variable template. Module variable template. Module variable
+      template. Module variable template. Module variable template. Module
+      variable template. Module variable template. Module variable template.
+    </h1>
+  </template> as TemplateOnlyComponent<Signature>,
+  ModVar2 = <template>
+    Second module variable template.
+  </template> as TemplateOnlyComponent<Signature>,
+  num = 1
+<template>
+  oops
+</template>
+
+const bool: boolean = false,
+  ModVar3 = <template>
+    <h1>
+      Module variable template. Module variable template. Module variable
+      template. Module variable template. Module variable template. Module
+      variable template. Module variable template. Module variable template.
+    </h1>
+  </template> as TemplateOnlyComponent<Signature>,
+  ModVar4 = <template>
+    Second module variable template.
+  </template> as TemplateOnlyComponent<Signature>
+<template>
+  oops
+</template>
+"
+`;
+
+exports[`ambiguous > config > semi: false > <template>oops</template> > with semi, without newline > it formats ../cases/gts/simple.gts 1`] = `
 "import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
 
 export interface Signature {
@@ -4255,6 +5588,324 @@ export interface Signature {
 "
 `;
 
+exports[`ambiguous > config > semi: false > ["oops"] > with semi, without newline > it formats ../cases/gjs/component-class.gjs 1`] = `
+"import Component from \\"@glimmer/component\\"
+
+/** It's a component */
+class MyComponent extends Component {
+  <template>
+    <h1>
+      Class top level template. Class top level template. Class top level
+      template. Class top level template. Class top level template.
+    </h1>
+  </template>;
+  [\\"oops\\"]
+}
+"
+`;
+
+exports[`ambiguous > config > semi: false > ["oops"] > with semi, without newline > it formats ../cases/gjs/component-class-with-content-before-template.gjs 1`] = `
+"import Component from \\"@glimmer/component\\"
+
+/** It's a component */
+class MyComponent extends Component {
+  get whatever() {}
+
+  <template>
+    <h1>
+      Class top level template. Class top level template. Class top level
+      template. Class top level template. Class top level template.
+    </h1>
+  </template>;
+  [\\"oops\\"]
+}
+"
+`;
+
+exports[`ambiguous > config > semi: false > ["oops"] > with semi, without newline > it formats ../cases/gjs/default-export.gjs 1`] = `
+"<template>
+  Explicit default export module top level component. Explicit default export
+  module top level component. Explicit default export module top level
+  component. Explicit default export module top level component. Explicit
+  default export module top level component.
+</template>
+;[\\"oops\\"]
+"
+`;
+
+exports[`ambiguous > config > semi: false > ["oops"] > with semi, without newline > it formats ../cases/gjs/exported-mod-var.gjs 1`] = `
+"export const Exported = <template>
+  Exported variable template. Exported variable template. Exported variable
+  template. Exported variable template. Exported variable template. Exported
+  variable template. Exported variable template.
+</template>
+;[\\"oops\\"]
+"
+`;
+
+exports[`ambiguous > config > semi: false > ["oops"] > with semi, without newline > it formats ../cases/gjs/js-only.gjs 1`] = `
+"const num = 1
+;[\\"oops\\"]
+"
+`;
+
+exports[`ambiguous > config > semi: false > ["oops"] > with semi, without newline > it formats ../cases/gjs/mod-var.gjs 1`] = `
+"const Private = <template>
+  Private variable template. Private variable template. Private variable
+  template. Private variable template. Private variable template. Private
+  variable template. Private variable template.
+</template>
+;[\\"oops\\"]
+
+const What = <template>Hi</template>
+;[\\"oops\\"]
+"
+`;
+
+exports[`ambiguous > config > semi: false > ["oops"] > with semi, without newline > it formats ../cases/gjs/multiple-declarations.gjs 1`] = `
+"const ModVar1 = <template>
+    <h1>
+      Module variable template. Module variable template. Module variable
+      template. Module variable template. Module variable template. Module
+      variable template. Module variable template. Module variable template.
+    </h1>
+  </template>,
+  ModVar2 = <template>Second module variable template.</template>,
+  num = 1
+;[\\"oops\\"]
+
+const bool = false,
+  ModVar3 = <template>
+    <h1>
+      Module variable template. Module variable template. Module variable
+      template. Module variable template. Module variable template. Module
+      variable template. Module variable template. Module variable template.
+    </h1>
+  </template>,
+  ModVar4 = <template>Second module variable template.</template>
+;[\\"oops\\"]
+"
+`;
+
+exports[`ambiguous > config > semi: false > ["oops"] > with semi, without newline > it formats ../cases/gjs/simple.gjs 1`] = `
+"<template>
+  what
+</template>
+;[\\"oops\\"]
+"
+`;
+
+exports[`ambiguous > config > semi: false > ["oops"] > with semi, without newline > it formats ../cases/gts/component-class.gts 1`] = `
+"import Component from \\"@glimmer/component\\"
+
+export interface Signature {
+  Element: HTMLElement
+  Args: {
+    myArg: string
+  }
+  Yields: []
+}
+
+/** It's a component */
+class MyComponent extends Component<Signature> {
+  <template>
+    <h1>
+      Class top level template. Class top level template. Class top level
+      template. Class top level template. Class top level template.
+    </h1>
+  </template>;
+  [\\"oops\\"]
+}
+"
+`;
+
+exports[`ambiguous > config > semi: false > ["oops"] > with semi, without newline > it formats ../cases/gts/default-export.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
+
+export interface Signature {
+  Element: HTMLElement
+  Args: {}
+  Yields: []
+}
+
+<template>
+  Explicit default export module top level component. Explicit default export
+  module top level component. Explicit default export module top level
+  component. Explicit default export module top level component. Explicit
+  default export module top level component.
+</template> as TemplateOnlyComponent<Signature>
+;[\\"oops\\"]
+"
+`;
+
+exports[`ambiguous > config > semi: false > ["oops"] > with semi, without newline > it formats ../cases/gts/exported-mod-var.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
+
+export interface Signature {
+  Element: HTMLElement
+  Args: {}
+  Yields: []
+}
+
+export const Exported: TemplateOnlyComponent<Signature> = <template>
+  Exported variable template. Exported variable template. Exported variable
+  template. Exported variable template. Exported variable template. Exported
+  variable template. Exported variable template.
+</template>
+;[\\"oops\\"]
+"
+`;
+
+exports[`ambiguous > config > semi: false > ["oops"] > with semi, without newline > it formats ../cases/gts/exported-mod-var-with-as.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
+
+export interface Signature {
+  Element: HTMLElement
+  Args: {}
+  Yields: []
+}
+
+export const Exported = <template>
+  Exported variable template. Exported variable template. Exported variable
+  template. Exported variable template. Exported variable template. Exported
+  variable template. Exported variable template.
+</template> as TemplateOnlyComponent<Signature>
+;[\\"oops\\"]
+"
+`;
+
+exports[`ambiguous > config > semi: false > ["oops"] > with semi, without newline > it formats ../cases/gts/js-only.gts 1`] = `
+"const num: number = 1
+;[\\"oops\\"]
+"
+`;
+
+exports[`ambiguous > config > semi: false > ["oops"] > with semi, without newline > it formats ../cases/gts/mod-var.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
+
+export interface Signature {
+  Element: HTMLElement
+  Args: {}
+  Yields: []
+}
+
+const Private: TemplateOnlyComponent<Signature> = <template>
+  Private variable template. Private variable template. Private variable
+  template. Private variable template. Private variable template. Private
+  variable template. Private variable template.
+</template>
+;[\\"oops\\"]
+"
+`;
+
+exports[`ambiguous > config > semi: false > ["oops"] > with semi, without newline > it formats ../cases/gts/mod-var-with-as.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
+
+export interface Signature {
+  Element: HTMLElement
+  Args: {}
+  Yields: []
+}
+
+const Private = <template>
+  Private variable template. Private variable template. Private variable
+  template. Private variable template. Private variable template. Private
+  variable template. Private variable template.
+</template> as TemplateOnlyComponent<Signature>
+;[\\"oops\\"]
+"
+`;
+
+exports[`ambiguous > config > semi: false > ["oops"] > with semi, without newline > it formats ../cases/gts/multiple-declarations.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
+
+export interface Signature {
+  Element: HTMLElement
+  Args: {}
+  Yields: []
+}
+
+const ModVar1: TemplateOnlyComponent<Signature> = <template>
+    <h1>
+      Module variable template. Module variable template. Module variable
+      template. Module variable template. Module variable template. Module
+      variable template. Module variable template. Module variable template.
+    </h1>
+  </template>,
+  ModVar2: TemplateOnlyComponent<Signature> = <template>
+    Second module variable template.
+  </template>,
+  num = 1
+;[\\"oops\\"]
+
+const bool: boolean = false,
+  ModVar3: TemplateOnlyComponent<Signature> = <template>
+    <h1>
+      Module variable template. Module variable template. Module variable
+      template. Module variable template. Module variable template. Module
+      variable template. Module variable template. Module variable template.
+    </h1>
+  </template>,
+  ModVar4: TemplateOnlyComponent<Signature> = <template>
+    Second module variable template.
+  </template>
+;[\\"oops\\"]
+"
+`;
+
+exports[`ambiguous > config > semi: false > ["oops"] > with semi, without newline > it formats ../cases/gts/multiple-declarations-with-as.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
+
+export interface Signature {
+  Element: HTMLElement
+  Args: {}
+  Yields: []
+}
+
+const ModVar1 = <template>
+    <h1>
+      Module variable template. Module variable template. Module variable
+      template. Module variable template. Module variable template. Module
+      variable template. Module variable template. Module variable template.
+    </h1>
+  </template> as TemplateOnlyComponent<Signature>,
+  ModVar2 = <template>
+    Second module variable template.
+  </template> as TemplateOnlyComponent<Signature>,
+  num = 1
+;[\\"oops\\"]
+
+const bool: boolean = false,
+  ModVar3 = <template>
+    <h1>
+      Module variable template. Module variable template. Module variable
+      template. Module variable template. Module variable template. Module
+      variable template. Module variable template. Module variable template.
+    </h1>
+  </template> as TemplateOnlyComponent<Signature>,
+  ModVar4 = <template>
+    Second module variable template.
+  </template> as TemplateOnlyComponent<Signature>
+;[\\"oops\\"]
+"
+`;
+
+exports[`ambiguous > config > semi: false > ["oops"] > with semi, without newline > it formats ../cases/gts/simple.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
+
+export interface Signature {
+  Element: HTMLElement
+  Args: {}
+  Yields: []
+}
+
+<template>
+  what
+</template> as TemplateOnlyComponent<Signature>
+;[\\"oops\\"]
+"
+`;
+
 exports[`ambiguous > config > semi: false > ["oops"] > without semi, with newline > it formats ../cases/gjs/component-class.gjs 1`] = `
 "import Component from \\"@glimmer/component\\"
 
@@ -5117,6 +6768,266 @@ export interface Signature {
 "
 `;
 
+exports[`ambiguous > config > semi: false > \`oops\` > with semi, without newline > it formats ../cases/gjs/default-export.gjs 1`] = `
+"<template>
+  Explicit default export module top level component. Explicit default export
+  module top level component. Explicit default export module top level
+  component. Explicit default export module top level component. Explicit
+  default export module top level component.
+</template>
+;\`oops\`
+"
+`;
+
+exports[`ambiguous > config > semi: false > \`oops\` > with semi, without newline > it formats ../cases/gjs/exported-mod-var.gjs 1`] = `
+"export const Exported = <template>
+  Exported variable template. Exported variable template. Exported variable
+  template. Exported variable template. Exported variable template. Exported
+  variable template. Exported variable template.
+</template>
+;\`oops\`
+"
+`;
+
+exports[`ambiguous > config > semi: false > \`oops\` > with semi, without newline > it formats ../cases/gjs/js-only.gjs 1`] = `
+"const num = 1
+;\`oops\`
+"
+`;
+
+exports[`ambiguous > config > semi: false > \`oops\` > with semi, without newline > it formats ../cases/gjs/mod-var.gjs 1`] = `
+"const Private = <template>
+  Private variable template. Private variable template. Private variable
+  template. Private variable template. Private variable template. Private
+  variable template. Private variable template.
+</template>
+;\`oops\`
+
+const What = <template>Hi</template>
+;\`oops\`
+"
+`;
+
+exports[`ambiguous > config > semi: false > \`oops\` > with semi, without newline > it formats ../cases/gjs/multiple-declarations.gjs 1`] = `
+"const ModVar1 = <template>
+    <h1>
+      Module variable template. Module variable template. Module variable
+      template. Module variable template. Module variable template. Module
+      variable template. Module variable template. Module variable template.
+    </h1>
+  </template>,
+  ModVar2 = <template>Second module variable template.</template>,
+  num = 1
+;\`oops\`
+
+const bool = false,
+  ModVar3 = <template>
+    <h1>
+      Module variable template. Module variable template. Module variable
+      template. Module variable template. Module variable template. Module
+      variable template. Module variable template. Module variable template.
+    </h1>
+  </template>,
+  ModVar4 = <template>Second module variable template.</template>
+;\`oops\`
+"
+`;
+
+exports[`ambiguous > config > semi: false > \`oops\` > with semi, without newline > it formats ../cases/gjs/simple.gjs 1`] = `
+"<template>
+  what
+</template>
+;\`oops\`
+"
+`;
+
+exports[`ambiguous > config > semi: false > \`oops\` > with semi, without newline > it formats ../cases/gts/default-export.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
+
+export interface Signature {
+  Element: HTMLElement
+  Args: {}
+  Yields: []
+}
+
+<template>
+  Explicit default export module top level component. Explicit default export
+  module top level component. Explicit default export module top level
+  component. Explicit default export module top level component. Explicit
+  default export module top level component.
+</template> as TemplateOnlyComponent<Signature>
+;\`oops\`
+"
+`;
+
+exports[`ambiguous > config > semi: false > \`oops\` > with semi, without newline > it formats ../cases/gts/exported-mod-var.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
+
+export interface Signature {
+  Element: HTMLElement
+  Args: {}
+  Yields: []
+}
+
+export const Exported: TemplateOnlyComponent<Signature> = <template>
+  Exported variable template. Exported variable template. Exported variable
+  template. Exported variable template. Exported variable template. Exported
+  variable template. Exported variable template.
+</template>
+;\`oops\`
+"
+`;
+
+exports[`ambiguous > config > semi: false > \`oops\` > with semi, without newline > it formats ../cases/gts/exported-mod-var-with-as.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
+
+export interface Signature {
+  Element: HTMLElement
+  Args: {}
+  Yields: []
+}
+
+export const Exported = <template>
+  Exported variable template. Exported variable template. Exported variable
+  template. Exported variable template. Exported variable template. Exported
+  variable template. Exported variable template.
+</template> as TemplateOnlyComponent<Signature>
+;\`oops\`
+"
+`;
+
+exports[`ambiguous > config > semi: false > \`oops\` > with semi, without newline > it formats ../cases/gts/js-only.gts 1`] = `
+"const num: number = 1
+;\`oops\`
+"
+`;
+
+exports[`ambiguous > config > semi: false > \`oops\` > with semi, without newline > it formats ../cases/gts/mod-var.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
+
+export interface Signature {
+  Element: HTMLElement
+  Args: {}
+  Yields: []
+}
+
+const Private: TemplateOnlyComponent<Signature> = <template>
+  Private variable template. Private variable template. Private variable
+  template. Private variable template. Private variable template. Private
+  variable template. Private variable template.
+</template>
+;\`oops\`
+"
+`;
+
+exports[`ambiguous > config > semi: false > \`oops\` > with semi, without newline > it formats ../cases/gts/mod-var-with-as.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
+
+export interface Signature {
+  Element: HTMLElement
+  Args: {}
+  Yields: []
+}
+
+const Private = <template>
+  Private variable template. Private variable template. Private variable
+  template. Private variable template. Private variable template. Private
+  variable template. Private variable template.
+</template> as TemplateOnlyComponent<Signature>
+;\`oops\`
+"
+`;
+
+exports[`ambiguous > config > semi: false > \`oops\` > with semi, without newline > it formats ../cases/gts/multiple-declarations.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
+
+export interface Signature {
+  Element: HTMLElement
+  Args: {}
+  Yields: []
+}
+
+const ModVar1: TemplateOnlyComponent<Signature> = <template>
+    <h1>
+      Module variable template. Module variable template. Module variable
+      template. Module variable template. Module variable template. Module
+      variable template. Module variable template. Module variable template.
+    </h1>
+  </template>,
+  ModVar2: TemplateOnlyComponent<Signature> = <template>
+    Second module variable template.
+  </template>,
+  num = 1
+;\`oops\`
+
+const bool: boolean = false,
+  ModVar3: TemplateOnlyComponent<Signature> = <template>
+    <h1>
+      Module variable template. Module variable template. Module variable
+      template. Module variable template. Module variable template. Module
+      variable template. Module variable template. Module variable template.
+    </h1>
+  </template>,
+  ModVar4: TemplateOnlyComponent<Signature> = <template>
+    Second module variable template.
+  </template>
+;\`oops\`
+"
+`;
+
+exports[`ambiguous > config > semi: false > \`oops\` > with semi, without newline > it formats ../cases/gts/multiple-declarations-with-as.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
+
+export interface Signature {
+  Element: HTMLElement
+  Args: {}
+  Yields: []
+}
+
+const ModVar1 = <template>
+    <h1>
+      Module variable template. Module variable template. Module variable
+      template. Module variable template. Module variable template. Module
+      variable template. Module variable template. Module variable template.
+    </h1>
+  </template> as TemplateOnlyComponent<Signature>,
+  ModVar2 = <template>
+    Second module variable template.
+  </template> as TemplateOnlyComponent<Signature>,
+  num = 1
+;\`oops\`
+
+const bool: boolean = false,
+  ModVar3 = <template>
+    <h1>
+      Module variable template. Module variable template. Module variable
+      template. Module variable template. Module variable template. Module
+      variable template. Module variable template. Module variable template.
+    </h1>
+  </template> as TemplateOnlyComponent<Signature>,
+  ModVar4 = <template>
+    Second module variable template.
+  </template> as TemplateOnlyComponent<Signature>
+;\`oops\`
+"
+`;
+
+exports[`ambiguous > config > semi: false > \`oops\` > with semi, without newline > it formats ../cases/gts/simple.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
+
+export interface Signature {
+  Element: HTMLElement
+  Args: {}
+  Yields: []
+}
+
+<template>
+  what
+</template> as TemplateOnlyComponent<Signature>
+;\`oops\`
+"
+`;
+
 exports[`ambiguous > config > semi: false > \`oops\` > without semi, with newline > it formats ../cases/gjs/js-only.gjs 1`] = `
 "const num = 1\`oops\`
 "
@@ -5851,6 +7762,266 @@ export interface Signature {
 `;
 
 exports[`ambiguous > config > semi: false > -"oops" > with semi, with newline > it formats ../cases/gts/simple.gts 2`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
+
+export interface Signature {
+  Element: HTMLElement
+  Args: {}
+  Yields: []
+}
+
+<template>
+  what
+</template> as TemplateOnlyComponent<Signature>
+;-\\"oops\\"
+"
+`;
+
+exports[`ambiguous > config > semi: false > -"oops" > with semi, without newline > it formats ../cases/gjs/default-export.gjs 1`] = `
+"<template>
+  Explicit default export module top level component. Explicit default export
+  module top level component. Explicit default export module top level
+  component. Explicit default export module top level component. Explicit
+  default export module top level component.
+</template>
+;-\\"oops\\"
+"
+`;
+
+exports[`ambiguous > config > semi: false > -"oops" > with semi, without newline > it formats ../cases/gjs/exported-mod-var.gjs 1`] = `
+"export const Exported = <template>
+  Exported variable template. Exported variable template. Exported variable
+  template. Exported variable template. Exported variable template. Exported
+  variable template. Exported variable template.
+</template>
+;-\\"oops\\"
+"
+`;
+
+exports[`ambiguous > config > semi: false > -"oops" > with semi, without newline > it formats ../cases/gjs/js-only.gjs 1`] = `
+"const num = 1
+;-\\"oops\\"
+"
+`;
+
+exports[`ambiguous > config > semi: false > -"oops" > with semi, without newline > it formats ../cases/gjs/mod-var.gjs 1`] = `
+"const Private = <template>
+  Private variable template. Private variable template. Private variable
+  template. Private variable template. Private variable template. Private
+  variable template. Private variable template.
+</template>
+;-\\"oops\\"
+
+const What = <template>Hi</template>
+;-\\"oops\\"
+"
+`;
+
+exports[`ambiguous > config > semi: false > -"oops" > with semi, without newline > it formats ../cases/gjs/multiple-declarations.gjs 1`] = `
+"const ModVar1 = <template>
+    <h1>
+      Module variable template. Module variable template. Module variable
+      template. Module variable template. Module variable template. Module
+      variable template. Module variable template. Module variable template.
+    </h1>
+  </template>,
+  ModVar2 = <template>Second module variable template.</template>,
+  num = 1
+;-\\"oops\\"
+
+const bool = false,
+  ModVar3 = <template>
+    <h1>
+      Module variable template. Module variable template. Module variable
+      template. Module variable template. Module variable template. Module
+      variable template. Module variable template. Module variable template.
+    </h1>
+  </template>,
+  ModVar4 = <template>Second module variable template.</template>
+;-\\"oops\\"
+"
+`;
+
+exports[`ambiguous > config > semi: false > -"oops" > with semi, without newline > it formats ../cases/gjs/simple.gjs 1`] = `
+"<template>
+  what
+</template>
+;-\\"oops\\"
+"
+`;
+
+exports[`ambiguous > config > semi: false > -"oops" > with semi, without newline > it formats ../cases/gts/default-export.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
+
+export interface Signature {
+  Element: HTMLElement
+  Args: {}
+  Yields: []
+}
+
+<template>
+  Explicit default export module top level component. Explicit default export
+  module top level component. Explicit default export module top level
+  component. Explicit default export module top level component. Explicit
+  default export module top level component.
+</template> as TemplateOnlyComponent<Signature>
+;-\\"oops\\"
+"
+`;
+
+exports[`ambiguous > config > semi: false > -"oops" > with semi, without newline > it formats ../cases/gts/exported-mod-var.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
+
+export interface Signature {
+  Element: HTMLElement
+  Args: {}
+  Yields: []
+}
+
+export const Exported: TemplateOnlyComponent<Signature> = <template>
+  Exported variable template. Exported variable template. Exported variable
+  template. Exported variable template. Exported variable template. Exported
+  variable template. Exported variable template.
+</template>
+;-\\"oops\\"
+"
+`;
+
+exports[`ambiguous > config > semi: false > -"oops" > with semi, without newline > it formats ../cases/gts/exported-mod-var-with-as.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
+
+export interface Signature {
+  Element: HTMLElement
+  Args: {}
+  Yields: []
+}
+
+export const Exported = <template>
+  Exported variable template. Exported variable template. Exported variable
+  template. Exported variable template. Exported variable template. Exported
+  variable template. Exported variable template.
+</template> as TemplateOnlyComponent<Signature>
+;-\\"oops\\"
+"
+`;
+
+exports[`ambiguous > config > semi: false > -"oops" > with semi, without newline > it formats ../cases/gts/js-only.gts 1`] = `
+"const num: number = 1
+;-\\"oops\\"
+"
+`;
+
+exports[`ambiguous > config > semi: false > -"oops" > with semi, without newline > it formats ../cases/gts/mod-var.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
+
+export interface Signature {
+  Element: HTMLElement
+  Args: {}
+  Yields: []
+}
+
+const Private: TemplateOnlyComponent<Signature> = <template>
+  Private variable template. Private variable template. Private variable
+  template. Private variable template. Private variable template. Private
+  variable template. Private variable template.
+</template>
+;-\\"oops\\"
+"
+`;
+
+exports[`ambiguous > config > semi: false > -"oops" > with semi, without newline > it formats ../cases/gts/mod-var-with-as.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
+
+export interface Signature {
+  Element: HTMLElement
+  Args: {}
+  Yields: []
+}
+
+const Private = <template>
+  Private variable template. Private variable template. Private variable
+  template. Private variable template. Private variable template. Private
+  variable template. Private variable template.
+</template> as TemplateOnlyComponent<Signature>
+;-\\"oops\\"
+"
+`;
+
+exports[`ambiguous > config > semi: false > -"oops" > with semi, without newline > it formats ../cases/gts/multiple-declarations.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
+
+export interface Signature {
+  Element: HTMLElement
+  Args: {}
+  Yields: []
+}
+
+const ModVar1: TemplateOnlyComponent<Signature> = <template>
+    <h1>
+      Module variable template. Module variable template. Module variable
+      template. Module variable template. Module variable template. Module
+      variable template. Module variable template. Module variable template.
+    </h1>
+  </template>,
+  ModVar2: TemplateOnlyComponent<Signature> = <template>
+    Second module variable template.
+  </template>,
+  num = 1
+;-\\"oops\\"
+
+const bool: boolean = false,
+  ModVar3: TemplateOnlyComponent<Signature> = <template>
+    <h1>
+      Module variable template. Module variable template. Module variable
+      template. Module variable template. Module variable template. Module
+      variable template. Module variable template. Module variable template.
+    </h1>
+  </template>,
+  ModVar4: TemplateOnlyComponent<Signature> = <template>
+    Second module variable template.
+  </template>
+;-\\"oops\\"
+"
+`;
+
+exports[`ambiguous > config > semi: false > -"oops" > with semi, without newline > it formats ../cases/gts/multiple-declarations-with-as.gts 1`] = `
+"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
+
+export interface Signature {
+  Element: HTMLElement
+  Args: {}
+  Yields: []
+}
+
+const ModVar1 = <template>
+    <h1>
+      Module variable template. Module variable template. Module variable
+      template. Module variable template. Module variable template. Module
+      variable template. Module variable template. Module variable template.
+    </h1>
+  </template> as TemplateOnlyComponent<Signature>,
+  ModVar2 = <template>
+    Second module variable template.
+  </template> as TemplateOnlyComponent<Signature>,
+  num = 1
+;-\\"oops\\"
+
+const bool: boolean = false,
+  ModVar3 = <template>
+    <h1>
+      Module variable template. Module variable template. Module variable
+      template. Module variable template. Module variable template. Module
+      variable template. Module variable template. Module variable template.
+    </h1>
+  </template> as TemplateOnlyComponent<Signature>,
+  ModVar4 = <template>
+    Second module variable template.
+  </template> as TemplateOnlyComponent<Signature>
+;-\\"oops\\"
+"
+`;
+
+exports[`ambiguous > config > semi: false > -"oops" > with semi, without newline > it formats ../cases/gts/simple.gts 1`] = `
 "import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
 
 export interface Signature {

--- a/tests/unit-tests/ambiguous/__snapshots__/semi-false.test.ts.snap
+++ b/tests/unit-tests/ambiguous/__snapshots__/semi-false.test.ts.snap
@@ -11,28 +11,7 @@ exports[`ambiguous > config > semi: false > (oh, no) => {} > with semi, with new
 "
 `;
 
-exports[`ambiguous > config > semi: false > (oh, no) => {} > with semi, with newline > it formats ../cases/gjs/default-export.gjs 2`] = `
-"<template>
-  Explicit default export module top level component. Explicit default export
-  module top level component. Explicit default export module top level
-  component. Explicit default export module top level component. Explicit
-  default export module top level component.
-</template>
-;(oh, no) => {}
-"
-`;
-
 exports[`ambiguous > config > semi: false > (oh, no) => {} > with semi, with newline > it formats ../cases/gjs/exported-mod-var.gjs 1`] = `
-"export const Exported = <template>
-  Exported variable template. Exported variable template. Exported variable
-  template. Exported variable template. Exported variable template. Exported
-  variable template. Exported variable template.
-</template>
-;(oh, no) => {}
-"
-`;
-
-exports[`ambiguous > config > semi: false > (oh, no) => {} > with semi, with newline > it formats ../cases/gjs/exported-mod-var.gjs 2`] = `
 "export const Exported = <template>
   Exported variable template. Exported variable template. Exported variable
   template. Exported variable template. Exported variable template. Exported
@@ -48,26 +27,7 @@ exports[`ambiguous > config > semi: false > (oh, no) => {} > with semi, with new
 "
 `;
 
-exports[`ambiguous > config > semi: false > (oh, no) => {} > with semi, with newline > it formats ../cases/gjs/js-only.gjs 2`] = `
-"const num = 1
-;(oh, no) => {}
-"
-`;
-
 exports[`ambiguous > config > semi: false > (oh, no) => {} > with semi, with newline > it formats ../cases/gjs/mod-var.gjs 1`] = `
-"const Private = <template>
-  Private variable template. Private variable template. Private variable
-  template. Private variable template. Private variable template. Private
-  variable template. Private variable template.
-</template>
-;(oh, no) => {}
-
-const What = <template>Hi</template>
-;(oh, no) => {}
-"
-`;
-
-exports[`ambiguous > config > semi: false > (oh, no) => {} > with semi, with newline > it formats ../cases/gjs/mod-var.gjs 2`] = `
 "const Private = <template>
   Private variable template. Private variable template. Private variable
   template. Private variable template. Private variable template. Private
@@ -105,31 +65,6 @@ const bool = false,
 "
 `;
 
-exports[`ambiguous > config > semi: false > (oh, no) => {} > with semi, with newline > it formats ../cases/gjs/multiple-declarations.gjs 2`] = `
-"const ModVar1 = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template>,
-  ModVar2 = <template>Second module variable template.</template>,
-  num = 1
-;(oh, no) => {}
-
-const bool = false,
-  ModVar3 = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template>,
-  ModVar4 = <template>Second module variable template.</template>
-;(oh, no) => {}
-"
-`;
-
 exports[`ambiguous > config > semi: false > (oh, no) => {} > with semi, with newline > it formats ../cases/gjs/simple.gjs 1`] = `
 "<template>
   what
@@ -138,34 +73,7 @@ exports[`ambiguous > config > semi: false > (oh, no) => {} > with semi, with new
 "
 `;
 
-exports[`ambiguous > config > semi: false > (oh, no) => {} > with semi, with newline > it formats ../cases/gjs/simple.gjs 2`] = `
-"<template>
-  what
-</template>
-;(oh, no) => {}
-"
-`;
-
 exports[`ambiguous > config > semi: false > (oh, no) => {} > with semi, with newline > it formats ../cases/gts/default-export.gts 1`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
-
-export interface Signature {
-  Element: HTMLElement
-  Args: {}
-  Yields: []
-}
-
-<template>
-  Explicit default export module top level component. Explicit default export
-  module top level component. Explicit default export module top level
-  component. Explicit default export module top level component. Explicit
-  default export module top level component.
-</template> as TemplateOnlyComponent<Signature>
-;(oh, no) => {}
-"
-`;
-
-exports[`ambiguous > config > semi: false > (oh, no) => {} > with semi, with newline > it formats ../cases/gts/default-export.gts 2`] = `
 "import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
 
 export interface Signature {
@@ -202,43 +110,7 @@ export const Exported: TemplateOnlyComponent<Signature> = <template>
 "
 `;
 
-exports[`ambiguous > config > semi: false > (oh, no) => {} > with semi, with newline > it formats ../cases/gts/exported-mod-var.gts 2`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
-
-export interface Signature {
-  Element: HTMLElement
-  Args: {}
-  Yields: []
-}
-
-export const Exported: TemplateOnlyComponent<Signature> = <template>
-  Exported variable template. Exported variable template. Exported variable
-  template. Exported variable template. Exported variable template. Exported
-  variable template. Exported variable template.
-</template>
-;(oh, no) => {}
-"
-`;
-
 exports[`ambiguous > config > semi: false > (oh, no) => {} > with semi, with newline > it formats ../cases/gts/exported-mod-var-with-as.gts 1`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
-
-export interface Signature {
-  Element: HTMLElement
-  Args: {}
-  Yields: []
-}
-
-export const Exported = <template>
-  Exported variable template. Exported variable template. Exported variable
-  template. Exported variable template. Exported variable template. Exported
-  variable template. Exported variable template.
-</template> as TemplateOnlyComponent<Signature>
-;(oh, no) => {}
-"
-`;
-
-exports[`ambiguous > config > semi: false > (oh, no) => {} > with semi, with newline > it formats ../cases/gts/exported-mod-var-with-as.gts 2`] = `
 "import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
 
 export interface Signature {
@@ -262,31 +134,7 @@ exports[`ambiguous > config > semi: false > (oh, no) => {} > with semi, with new
 "
 `;
 
-exports[`ambiguous > config > semi: false > (oh, no) => {} > with semi, with newline > it formats ../cases/gts/js-only.gts 2`] = `
-"const num: number = 1
-;(oh, no) => {}
-"
-`;
-
 exports[`ambiguous > config > semi: false > (oh, no) => {} > with semi, with newline > it formats ../cases/gts/mod-var.gts 1`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
-
-export interface Signature {
-  Element: HTMLElement
-  Args: {}
-  Yields: []
-}
-
-const Private: TemplateOnlyComponent<Signature> = <template>
-  Private variable template. Private variable template. Private variable
-  template. Private variable template. Private variable template. Private
-  variable template. Private variable template.
-</template>
-;(oh, no) => {}
-"
-`;
-
-exports[`ambiguous > config > semi: false > (oh, no) => {} > with semi, with newline > it formats ../cases/gts/mod-var.gts 2`] = `
 "import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
 
 export interface Signature {
@@ -322,62 +170,7 @@ const Private = <template>
 "
 `;
 
-exports[`ambiguous > config > semi: false > (oh, no) => {} > with semi, with newline > it formats ../cases/gts/mod-var-with-as.gts 2`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
-
-export interface Signature {
-  Element: HTMLElement
-  Args: {}
-  Yields: []
-}
-
-const Private = <template>
-  Private variable template. Private variable template. Private variable
-  template. Private variable template. Private variable template. Private
-  variable template. Private variable template.
-</template> as TemplateOnlyComponent<Signature>
-;(oh, no) => {}
-"
-`;
-
 exports[`ambiguous > config > semi: false > (oh, no) => {} > with semi, with newline > it formats ../cases/gts/multiple-declarations.gts 1`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
-
-export interface Signature {
-  Element: HTMLElement
-  Args: {}
-  Yields: []
-}
-
-const ModVar1: TemplateOnlyComponent<Signature> = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template>,
-  ModVar2: TemplateOnlyComponent<Signature> = <template>
-    Second module variable template.
-  </template>,
-  num = 1
-;(oh, no) => {}
-
-const bool: boolean = false,
-  ModVar3: TemplateOnlyComponent<Signature> = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template>,
-  ModVar4: TemplateOnlyComponent<Signature> = <template>
-    Second module variable template.
-  </template>
-;(oh, no) => {}
-"
-`;
-
-exports[`ambiguous > config > semi: false > (oh, no) => {} > with semi, with newline > it formats ../cases/gts/multiple-declarations.gts 2`] = `
 "import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
 
 export interface Signature {
@@ -451,60 +244,7 @@ const bool: boolean = false,
 "
 `;
 
-exports[`ambiguous > config > semi: false > (oh, no) => {} > with semi, with newline > it formats ../cases/gts/multiple-declarations-with-as.gts 2`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
-
-export interface Signature {
-  Element: HTMLElement
-  Args: {}
-  Yields: []
-}
-
-const ModVar1 = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template> as TemplateOnlyComponent<Signature>,
-  ModVar2 = <template>
-    Second module variable template.
-  </template> as TemplateOnlyComponent<Signature>,
-  num = 1
-;(oh, no) => {}
-
-const bool: boolean = false,
-  ModVar3 = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template> as TemplateOnlyComponent<Signature>,
-  ModVar4 = <template>
-    Second module variable template.
-  </template> as TemplateOnlyComponent<Signature>
-;(oh, no) => {}
-"
-`;
-
 exports[`ambiguous > config > semi: false > (oh, no) => {} > with semi, with newline > it formats ../cases/gts/simple.gts 1`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
-
-export interface Signature {
-  Element: HTMLElement
-  Args: {}
-  Yields: []
-}
-
-<template>
-  what
-</template> as TemplateOnlyComponent<Signature>
-;(oh, no) => {}
-"
-`;
-
-exports[`ambiguous > config > semi: false > (oh, no) => {} > with semi, with newline > it formats ../cases/gts/simple.gts 2`] = `
 "import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
 
 export interface Signature {
@@ -929,28 +669,7 @@ exports[`ambiguous > config > semi: false > (oops) => {} > with semi, with newli
 "
 `;
 
-exports[`ambiguous > config > semi: false > (oops) => {} > with semi, with newline > it formats ../cases/gjs/default-export.gjs 2`] = `
-"<template>
-  Explicit default export module top level component. Explicit default export
-  module top level component. Explicit default export module top level
-  component. Explicit default export module top level component. Explicit
-  default export module top level component.
-</template>
-;(oops) => {}
-"
-`;
-
 exports[`ambiguous > config > semi: false > (oops) => {} > with semi, with newline > it formats ../cases/gjs/exported-mod-var.gjs 1`] = `
-"export const Exported = <template>
-  Exported variable template. Exported variable template. Exported variable
-  template. Exported variable template. Exported variable template. Exported
-  variable template. Exported variable template.
-</template>
-;(oops) => {}
-"
-`;
-
-exports[`ambiguous > config > semi: false > (oops) => {} > with semi, with newline > it formats ../cases/gjs/exported-mod-var.gjs 2`] = `
 "export const Exported = <template>
   Exported variable template. Exported variable template. Exported variable
   template. Exported variable template. Exported variable template. Exported
@@ -966,26 +685,7 @@ exports[`ambiguous > config > semi: false > (oops) => {} > with semi, with newli
 "
 `;
 
-exports[`ambiguous > config > semi: false > (oops) => {} > with semi, with newline > it formats ../cases/gjs/js-only.gjs 2`] = `
-"const num = 1
-;(oops) => {}
-"
-`;
-
 exports[`ambiguous > config > semi: false > (oops) => {} > with semi, with newline > it formats ../cases/gjs/mod-var.gjs 1`] = `
-"const Private = <template>
-  Private variable template. Private variable template. Private variable
-  template. Private variable template. Private variable template. Private
-  variable template. Private variable template.
-</template>
-;(oops) => {}
-
-const What = <template>Hi</template>
-;(oops) => {}
-"
-`;
-
-exports[`ambiguous > config > semi: false > (oops) => {} > with semi, with newline > it formats ../cases/gjs/mod-var.gjs 2`] = `
 "const Private = <template>
   Private variable template. Private variable template. Private variable
   template. Private variable template. Private variable template. Private
@@ -1023,31 +723,6 @@ const bool = false,
 "
 `;
 
-exports[`ambiguous > config > semi: false > (oops) => {} > with semi, with newline > it formats ../cases/gjs/multiple-declarations.gjs 2`] = `
-"const ModVar1 = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template>,
-  ModVar2 = <template>Second module variable template.</template>,
-  num = 1
-;(oops) => {}
-
-const bool = false,
-  ModVar3 = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template>,
-  ModVar4 = <template>Second module variable template.</template>
-;(oops) => {}
-"
-`;
-
 exports[`ambiguous > config > semi: false > (oops) => {} > with semi, with newline > it formats ../cases/gjs/simple.gjs 1`] = `
 "<template>
   what
@@ -1056,34 +731,7 @@ exports[`ambiguous > config > semi: false > (oops) => {} > with semi, with newli
 "
 `;
 
-exports[`ambiguous > config > semi: false > (oops) => {} > with semi, with newline > it formats ../cases/gjs/simple.gjs 2`] = `
-"<template>
-  what
-</template>
-;(oops) => {}
-"
-`;
-
 exports[`ambiguous > config > semi: false > (oops) => {} > with semi, with newline > it formats ../cases/gts/default-export.gts 1`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
-
-export interface Signature {
-  Element: HTMLElement
-  Args: {}
-  Yields: []
-}
-
-<template>
-  Explicit default export module top level component. Explicit default export
-  module top level component. Explicit default export module top level
-  component. Explicit default export module top level component. Explicit
-  default export module top level component.
-</template> as TemplateOnlyComponent<Signature>
-;(oops) => {}
-"
-`;
-
-exports[`ambiguous > config > semi: false > (oops) => {} > with semi, with newline > it formats ../cases/gts/default-export.gts 2`] = `
 "import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
 
 export interface Signature {
@@ -1120,43 +768,7 @@ export const Exported: TemplateOnlyComponent<Signature> = <template>
 "
 `;
 
-exports[`ambiguous > config > semi: false > (oops) => {} > with semi, with newline > it formats ../cases/gts/exported-mod-var.gts 2`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
-
-export interface Signature {
-  Element: HTMLElement
-  Args: {}
-  Yields: []
-}
-
-export const Exported: TemplateOnlyComponent<Signature> = <template>
-  Exported variable template. Exported variable template. Exported variable
-  template. Exported variable template. Exported variable template. Exported
-  variable template. Exported variable template.
-</template>
-;(oops) => {}
-"
-`;
-
 exports[`ambiguous > config > semi: false > (oops) => {} > with semi, with newline > it formats ../cases/gts/exported-mod-var-with-as.gts 1`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
-
-export interface Signature {
-  Element: HTMLElement
-  Args: {}
-  Yields: []
-}
-
-export const Exported = <template>
-  Exported variable template. Exported variable template. Exported variable
-  template. Exported variable template. Exported variable template. Exported
-  variable template. Exported variable template.
-</template> as TemplateOnlyComponent<Signature>
-;(oops) => {}
-"
-`;
-
-exports[`ambiguous > config > semi: false > (oops) => {} > with semi, with newline > it formats ../cases/gts/exported-mod-var-with-as.gts 2`] = `
 "import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
 
 export interface Signature {
@@ -1180,31 +792,7 @@ exports[`ambiguous > config > semi: false > (oops) => {} > with semi, with newli
 "
 `;
 
-exports[`ambiguous > config > semi: false > (oops) => {} > with semi, with newline > it formats ../cases/gts/js-only.gts 2`] = `
-"const num: number = 1
-;(oops) => {}
-"
-`;
-
 exports[`ambiguous > config > semi: false > (oops) => {} > with semi, with newline > it formats ../cases/gts/mod-var.gts 1`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
-
-export interface Signature {
-  Element: HTMLElement
-  Args: {}
-  Yields: []
-}
-
-const Private: TemplateOnlyComponent<Signature> = <template>
-  Private variable template. Private variable template. Private variable
-  template. Private variable template. Private variable template. Private
-  variable template. Private variable template.
-</template>
-;(oops) => {}
-"
-`;
-
-exports[`ambiguous > config > semi: false > (oops) => {} > with semi, with newline > it formats ../cases/gts/mod-var.gts 2`] = `
 "import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
 
 export interface Signature {
@@ -1240,62 +828,7 @@ const Private = <template>
 "
 `;
 
-exports[`ambiguous > config > semi: false > (oops) => {} > with semi, with newline > it formats ../cases/gts/mod-var-with-as.gts 2`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
-
-export interface Signature {
-  Element: HTMLElement
-  Args: {}
-  Yields: []
-}
-
-const Private = <template>
-  Private variable template. Private variable template. Private variable
-  template. Private variable template. Private variable template. Private
-  variable template. Private variable template.
-</template> as TemplateOnlyComponent<Signature>
-;(oops) => {}
-"
-`;
-
 exports[`ambiguous > config > semi: false > (oops) => {} > with semi, with newline > it formats ../cases/gts/multiple-declarations.gts 1`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
-
-export interface Signature {
-  Element: HTMLElement
-  Args: {}
-  Yields: []
-}
-
-const ModVar1: TemplateOnlyComponent<Signature> = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template>,
-  ModVar2: TemplateOnlyComponent<Signature> = <template>
-    Second module variable template.
-  </template>,
-  num = 1
-;(oops) => {}
-
-const bool: boolean = false,
-  ModVar3: TemplateOnlyComponent<Signature> = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template>,
-  ModVar4: TemplateOnlyComponent<Signature> = <template>
-    Second module variable template.
-  </template>
-;(oops) => {}
-"
-`;
-
-exports[`ambiguous > config > semi: false > (oops) => {} > with semi, with newline > it formats ../cases/gts/multiple-declarations.gts 2`] = `
 "import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
 
 export interface Signature {
@@ -1369,60 +902,7 @@ const bool: boolean = false,
 "
 `;
 
-exports[`ambiguous > config > semi: false > (oops) => {} > with semi, with newline > it formats ../cases/gts/multiple-declarations-with-as.gts 2`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
-
-export interface Signature {
-  Element: HTMLElement
-  Args: {}
-  Yields: []
-}
-
-const ModVar1 = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template> as TemplateOnlyComponent<Signature>,
-  ModVar2 = <template>
-    Second module variable template.
-  </template> as TemplateOnlyComponent<Signature>,
-  num = 1
-;(oops) => {}
-
-const bool: boolean = false,
-  ModVar3 = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template> as TemplateOnlyComponent<Signature>,
-  ModVar4 = <template>
-    Second module variable template.
-  </template> as TemplateOnlyComponent<Signature>
-;(oops) => {}
-"
-`;
-
 exports[`ambiguous > config > semi: false > (oops) => {} > with semi, with newline > it formats ../cases/gts/simple.gts 1`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
-
-export interface Signature {
-  Element: HTMLElement
-  Args: {}
-  Yields: []
-}
-
-<template>
-  what
-</template> as TemplateOnlyComponent<Signature>
-;(oops) => {}
-"
-`;
-
-exports[`ambiguous > config > semi: false > (oops) => {} > with semi, with newline > it formats ../cases/gts/simple.gts 2`] = `
 "import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
 
 export interface Signature {
@@ -1847,28 +1327,7 @@ exports[`ambiguous > config > semi: false > +"oops" > with semi, with newline > 
 "
 `;
 
-exports[`ambiguous > config > semi: false > +"oops" > with semi, with newline > it formats ../cases/gjs/default-export.gjs 2`] = `
-"<template>
-  Explicit default export module top level component. Explicit default export
-  module top level component. Explicit default export module top level
-  component. Explicit default export module top level component. Explicit
-  default export module top level component.
-</template>
-;+\\"oops\\"
-"
-`;
-
 exports[`ambiguous > config > semi: false > +"oops" > with semi, with newline > it formats ../cases/gjs/exported-mod-var.gjs 1`] = `
-"export const Exported = <template>
-  Exported variable template. Exported variable template. Exported variable
-  template. Exported variable template. Exported variable template. Exported
-  variable template. Exported variable template.
-</template>
-;+\\"oops\\"
-"
-`;
-
-exports[`ambiguous > config > semi: false > +"oops" > with semi, with newline > it formats ../cases/gjs/exported-mod-var.gjs 2`] = `
 "export const Exported = <template>
   Exported variable template. Exported variable template. Exported variable
   template. Exported variable template. Exported variable template. Exported
@@ -1884,26 +1343,7 @@ exports[`ambiguous > config > semi: false > +"oops" > with semi, with newline > 
 "
 `;
 
-exports[`ambiguous > config > semi: false > +"oops" > with semi, with newline > it formats ../cases/gjs/js-only.gjs 2`] = `
-"const num = 1
-;+\\"oops\\"
-"
-`;
-
 exports[`ambiguous > config > semi: false > +"oops" > with semi, with newline > it formats ../cases/gjs/mod-var.gjs 1`] = `
-"const Private = <template>
-  Private variable template. Private variable template. Private variable
-  template. Private variable template. Private variable template. Private
-  variable template. Private variable template.
-</template>
-;+\\"oops\\"
-
-const What = <template>Hi</template>
-;+\\"oops\\"
-"
-`;
-
-exports[`ambiguous > config > semi: false > +"oops" > with semi, with newline > it formats ../cases/gjs/mod-var.gjs 2`] = `
 "const Private = <template>
   Private variable template. Private variable template. Private variable
   template. Private variable template. Private variable template. Private
@@ -1941,31 +1381,6 @@ const bool = false,
 "
 `;
 
-exports[`ambiguous > config > semi: false > +"oops" > with semi, with newline > it formats ../cases/gjs/multiple-declarations.gjs 2`] = `
-"const ModVar1 = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template>,
-  ModVar2 = <template>Second module variable template.</template>,
-  num = 1
-;+\\"oops\\"
-
-const bool = false,
-  ModVar3 = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template>,
-  ModVar4 = <template>Second module variable template.</template>
-;+\\"oops\\"
-"
-`;
-
 exports[`ambiguous > config > semi: false > +"oops" > with semi, with newline > it formats ../cases/gjs/simple.gjs 1`] = `
 "<template>
   what
@@ -1974,34 +1389,7 @@ exports[`ambiguous > config > semi: false > +"oops" > with semi, with newline > 
 "
 `;
 
-exports[`ambiguous > config > semi: false > +"oops" > with semi, with newline > it formats ../cases/gjs/simple.gjs 2`] = `
-"<template>
-  what
-</template>
-;+\\"oops\\"
-"
-`;
-
 exports[`ambiguous > config > semi: false > +"oops" > with semi, with newline > it formats ../cases/gts/default-export.gts 1`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
-
-export interface Signature {
-  Element: HTMLElement
-  Args: {}
-  Yields: []
-}
-
-<template>
-  Explicit default export module top level component. Explicit default export
-  module top level component. Explicit default export module top level
-  component. Explicit default export module top level component. Explicit
-  default export module top level component.
-</template> as TemplateOnlyComponent<Signature>
-;+\\"oops\\"
-"
-`;
-
-exports[`ambiguous > config > semi: false > +"oops" > with semi, with newline > it formats ../cases/gts/default-export.gts 2`] = `
 "import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
 
 export interface Signature {
@@ -2038,43 +1426,7 @@ export const Exported: TemplateOnlyComponent<Signature> = <template>
 "
 `;
 
-exports[`ambiguous > config > semi: false > +"oops" > with semi, with newline > it formats ../cases/gts/exported-mod-var.gts 2`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
-
-export interface Signature {
-  Element: HTMLElement
-  Args: {}
-  Yields: []
-}
-
-export const Exported: TemplateOnlyComponent<Signature> = <template>
-  Exported variable template. Exported variable template. Exported variable
-  template. Exported variable template. Exported variable template. Exported
-  variable template. Exported variable template.
-</template>
-;+\\"oops\\"
-"
-`;
-
 exports[`ambiguous > config > semi: false > +"oops" > with semi, with newline > it formats ../cases/gts/exported-mod-var-with-as.gts 1`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
-
-export interface Signature {
-  Element: HTMLElement
-  Args: {}
-  Yields: []
-}
-
-export const Exported = <template>
-  Exported variable template. Exported variable template. Exported variable
-  template. Exported variable template. Exported variable template. Exported
-  variable template. Exported variable template.
-</template> as TemplateOnlyComponent<Signature>
-;+\\"oops\\"
-"
-`;
-
-exports[`ambiguous > config > semi: false > +"oops" > with semi, with newline > it formats ../cases/gts/exported-mod-var-with-as.gts 2`] = `
 "import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
 
 export interface Signature {
@@ -2098,31 +1450,7 @@ exports[`ambiguous > config > semi: false > +"oops" > with semi, with newline > 
 "
 `;
 
-exports[`ambiguous > config > semi: false > +"oops" > with semi, with newline > it formats ../cases/gts/js-only.gts 2`] = `
-"const num: number = 1
-;+\\"oops\\"
-"
-`;
-
 exports[`ambiguous > config > semi: false > +"oops" > with semi, with newline > it formats ../cases/gts/mod-var.gts 1`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
-
-export interface Signature {
-  Element: HTMLElement
-  Args: {}
-  Yields: []
-}
-
-const Private: TemplateOnlyComponent<Signature> = <template>
-  Private variable template. Private variable template. Private variable
-  template. Private variable template. Private variable template. Private
-  variable template. Private variable template.
-</template>
-;+\\"oops\\"
-"
-`;
-
-exports[`ambiguous > config > semi: false > +"oops" > with semi, with newline > it formats ../cases/gts/mod-var.gts 2`] = `
 "import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
 
 export interface Signature {
@@ -2158,62 +1486,7 @@ const Private = <template>
 "
 `;
 
-exports[`ambiguous > config > semi: false > +"oops" > with semi, with newline > it formats ../cases/gts/mod-var-with-as.gts 2`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
-
-export interface Signature {
-  Element: HTMLElement
-  Args: {}
-  Yields: []
-}
-
-const Private = <template>
-  Private variable template. Private variable template. Private variable
-  template. Private variable template. Private variable template. Private
-  variable template. Private variable template.
-</template> as TemplateOnlyComponent<Signature>
-;+\\"oops\\"
-"
-`;
-
 exports[`ambiguous > config > semi: false > +"oops" > with semi, with newline > it formats ../cases/gts/multiple-declarations.gts 1`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
-
-export interface Signature {
-  Element: HTMLElement
-  Args: {}
-  Yields: []
-}
-
-const ModVar1: TemplateOnlyComponent<Signature> = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template>,
-  ModVar2: TemplateOnlyComponent<Signature> = <template>
-    Second module variable template.
-  </template>,
-  num = 1
-;+\\"oops\\"
-
-const bool: boolean = false,
-  ModVar3: TemplateOnlyComponent<Signature> = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template>,
-  ModVar4: TemplateOnlyComponent<Signature> = <template>
-    Second module variable template.
-  </template>
-;+\\"oops\\"
-"
-`;
-
-exports[`ambiguous > config > semi: false > +"oops" > with semi, with newline > it formats ../cases/gts/multiple-declarations.gts 2`] = `
 "import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
 
 export interface Signature {
@@ -2287,60 +1560,7 @@ const bool: boolean = false,
 "
 `;
 
-exports[`ambiguous > config > semi: false > +"oops" > with semi, with newline > it formats ../cases/gts/multiple-declarations-with-as.gts 2`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
-
-export interface Signature {
-  Element: HTMLElement
-  Args: {}
-  Yields: []
-}
-
-const ModVar1 = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template> as TemplateOnlyComponent<Signature>,
-  ModVar2 = <template>
-    Second module variable template.
-  </template> as TemplateOnlyComponent<Signature>,
-  num = 1
-;+\\"oops\\"
-
-const bool: boolean = false,
-  ModVar3 = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template> as TemplateOnlyComponent<Signature>,
-  ModVar4 = <template>
-    Second module variable template.
-  </template> as TemplateOnlyComponent<Signature>
-;+\\"oops\\"
-"
-`;
-
 exports[`ambiguous > config > semi: false > +"oops" > with semi, with newline > it formats ../cases/gts/simple.gts 1`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
-
-export interface Signature {
-  Element: HTMLElement
-  Args: {}
-  Yields: []
-}
-
-<template>
-  what
-</template> as TemplateOnlyComponent<Signature>
-;+\\"oops\\"
-"
-`;
-
-exports[`ambiguous > config > semi: false > +"oops" > with semi, with newline > it formats ../cases/gts/simple.gts 2`] = `
 "import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
 
 export interface Signature {
@@ -2647,28 +1867,7 @@ exports[`ambiguous > config > semi: false > /oops/ > with semi, with newline > i
 "
 `;
 
-exports[`ambiguous > config > semi: false > /oops/ > with semi, with newline > it formats ../cases/gjs/default-export.gjs 2`] = `
-"<template>
-  Explicit default export module top level component. Explicit default export
-  module top level component. Explicit default export module top level
-  component. Explicit default export module top level component. Explicit
-  default export module top level component.
-</template>
-;/oops/
-"
-`;
-
 exports[`ambiguous > config > semi: false > /oops/ > with semi, with newline > it formats ../cases/gjs/exported-mod-var.gjs 1`] = `
-"export const Exported = <template>
-  Exported variable template. Exported variable template. Exported variable
-  template. Exported variable template. Exported variable template. Exported
-  variable template. Exported variable template.
-</template>
-;/oops/
-"
-`;
-
-exports[`ambiguous > config > semi: false > /oops/ > with semi, with newline > it formats ../cases/gjs/exported-mod-var.gjs 2`] = `
 "export const Exported = <template>
   Exported variable template. Exported variable template. Exported variable
   template. Exported variable template. Exported variable template. Exported
@@ -2684,26 +1883,7 @@ exports[`ambiguous > config > semi: false > /oops/ > with semi, with newline > i
 "
 `;
 
-exports[`ambiguous > config > semi: false > /oops/ > with semi, with newline > it formats ../cases/gjs/js-only.gjs 2`] = `
-"const num = 1
-;/oops/
-"
-`;
-
 exports[`ambiguous > config > semi: false > /oops/ > with semi, with newline > it formats ../cases/gjs/mod-var.gjs 1`] = `
-"const Private = <template>
-  Private variable template. Private variable template. Private variable
-  template. Private variable template. Private variable template. Private
-  variable template. Private variable template.
-</template>
-;/oops/
-
-const What = <template>Hi</template>
-;/oops/
-"
-`;
-
-exports[`ambiguous > config > semi: false > /oops/ > with semi, with newline > it formats ../cases/gjs/mod-var.gjs 2`] = `
 "const Private = <template>
   Private variable template. Private variable template. Private variable
   template. Private variable template. Private variable template. Private
@@ -2741,31 +1921,6 @@ const bool = false,
 "
 `;
 
-exports[`ambiguous > config > semi: false > /oops/ > with semi, with newline > it formats ../cases/gjs/multiple-declarations.gjs 2`] = `
-"const ModVar1 = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template>,
-  ModVar2 = <template>Second module variable template.</template>,
-  num = 1
-;/oops/
-
-const bool = false,
-  ModVar3 = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template>,
-  ModVar4 = <template>Second module variable template.</template>
-;/oops/
-"
-`;
-
 exports[`ambiguous > config > semi: false > /oops/ > with semi, with newline > it formats ../cases/gjs/simple.gjs 1`] = `
 "<template>
   what
@@ -2774,34 +1929,7 @@ exports[`ambiguous > config > semi: false > /oops/ > with semi, with newline > i
 "
 `;
 
-exports[`ambiguous > config > semi: false > /oops/ > with semi, with newline > it formats ../cases/gjs/simple.gjs 2`] = `
-"<template>
-  what
-</template>
-;/oops/
-"
-`;
-
 exports[`ambiguous > config > semi: false > /oops/ > with semi, with newline > it formats ../cases/gts/default-export.gts 1`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
-
-export interface Signature {
-  Element: HTMLElement
-  Args: {}
-  Yields: []
-}
-
-<template>
-  Explicit default export module top level component. Explicit default export
-  module top level component. Explicit default export module top level
-  component. Explicit default export module top level component. Explicit
-  default export module top level component.
-</template> as TemplateOnlyComponent<Signature>
-;/oops/
-"
-`;
-
-exports[`ambiguous > config > semi: false > /oops/ > with semi, with newline > it formats ../cases/gts/default-export.gts 2`] = `
 "import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
 
 export interface Signature {
@@ -2838,43 +1966,7 @@ export const Exported: TemplateOnlyComponent<Signature> = <template>
 "
 `;
 
-exports[`ambiguous > config > semi: false > /oops/ > with semi, with newline > it formats ../cases/gts/exported-mod-var.gts 2`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
-
-export interface Signature {
-  Element: HTMLElement
-  Args: {}
-  Yields: []
-}
-
-export const Exported: TemplateOnlyComponent<Signature> = <template>
-  Exported variable template. Exported variable template. Exported variable
-  template. Exported variable template. Exported variable template. Exported
-  variable template. Exported variable template.
-</template>
-;/oops/
-"
-`;
-
 exports[`ambiguous > config > semi: false > /oops/ > with semi, with newline > it formats ../cases/gts/exported-mod-var-with-as.gts 1`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
-
-export interface Signature {
-  Element: HTMLElement
-  Args: {}
-  Yields: []
-}
-
-export const Exported = <template>
-  Exported variable template. Exported variable template. Exported variable
-  template. Exported variable template. Exported variable template. Exported
-  variable template. Exported variable template.
-</template> as TemplateOnlyComponent<Signature>
-;/oops/
-"
-`;
-
-exports[`ambiguous > config > semi: false > /oops/ > with semi, with newline > it formats ../cases/gts/exported-mod-var-with-as.gts 2`] = `
 "import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
 
 export interface Signature {
@@ -2898,31 +1990,7 @@ exports[`ambiguous > config > semi: false > /oops/ > with semi, with newline > i
 "
 `;
 
-exports[`ambiguous > config > semi: false > /oops/ > with semi, with newline > it formats ../cases/gts/js-only.gts 2`] = `
-"const num: number = 1
-;/oops/
-"
-`;
-
 exports[`ambiguous > config > semi: false > /oops/ > with semi, with newline > it formats ../cases/gts/mod-var.gts 1`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
-
-export interface Signature {
-  Element: HTMLElement
-  Args: {}
-  Yields: []
-}
-
-const Private: TemplateOnlyComponent<Signature> = <template>
-  Private variable template. Private variable template. Private variable
-  template. Private variable template. Private variable template. Private
-  variable template. Private variable template.
-</template>
-;/oops/
-"
-`;
-
-exports[`ambiguous > config > semi: false > /oops/ > with semi, with newline > it formats ../cases/gts/mod-var.gts 2`] = `
 "import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
 
 export interface Signature {
@@ -2958,62 +2026,7 @@ const Private = <template>
 "
 `;
 
-exports[`ambiguous > config > semi: false > /oops/ > with semi, with newline > it formats ../cases/gts/mod-var-with-as.gts 2`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
-
-export interface Signature {
-  Element: HTMLElement
-  Args: {}
-  Yields: []
-}
-
-const Private = <template>
-  Private variable template. Private variable template. Private variable
-  template. Private variable template. Private variable template. Private
-  variable template. Private variable template.
-</template> as TemplateOnlyComponent<Signature>
-;/oops/
-"
-`;
-
 exports[`ambiguous > config > semi: false > /oops/ > with semi, with newline > it formats ../cases/gts/multiple-declarations.gts 1`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
-
-export interface Signature {
-  Element: HTMLElement
-  Args: {}
-  Yields: []
-}
-
-const ModVar1: TemplateOnlyComponent<Signature> = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template>,
-  ModVar2: TemplateOnlyComponent<Signature> = <template>
-    Second module variable template.
-  </template>,
-  num = 1
-;/oops/
-
-const bool: boolean = false,
-  ModVar3: TemplateOnlyComponent<Signature> = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template>,
-  ModVar4: TemplateOnlyComponent<Signature> = <template>
-    Second module variable template.
-  </template>
-;/oops/
-"
-`;
-
-exports[`ambiguous > config > semi: false > /oops/ > with semi, with newline > it formats ../cases/gts/multiple-declarations.gts 2`] = `
 "import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
 
 export interface Signature {
@@ -3087,60 +2100,7 @@ const bool: boolean = false,
 "
 `;
 
-exports[`ambiguous > config > semi: false > /oops/ > with semi, with newline > it formats ../cases/gts/multiple-declarations-with-as.gts 2`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
-
-export interface Signature {
-  Element: HTMLElement
-  Args: {}
-  Yields: []
-}
-
-const ModVar1 = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template> as TemplateOnlyComponent<Signature>,
-  ModVar2 = <template>
-    Second module variable template.
-  </template> as TemplateOnlyComponent<Signature>,
-  num = 1
-;/oops/
-
-const bool: boolean = false,
-  ModVar3 = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template> as TemplateOnlyComponent<Signature>,
-  ModVar4 = <template>
-    Second module variable template.
-  </template> as TemplateOnlyComponent<Signature>
-;/oops/
-"
-`;
-
 exports[`ambiguous > config > semi: false > /oops/ > with semi, with newline > it formats ../cases/gts/simple.gts 1`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
-
-export interface Signature {
-  Element: HTMLElement
-  Args: {}
-  Yields: []
-}
-
-<template>
-  what
-</template> as TemplateOnlyComponent<Signature>
-;/oops/
-"
-`;
-
-exports[`ambiguous > config > semi: false > /oops/ > with semi, with newline > it formats ../cases/gts/simple.gts 2`] = `
 "import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
 
 export interface Signature {
@@ -3467,19 +2427,6 @@ exports[`ambiguous > config > semi: false > <template>oops</template> > with sem
 "
 `;
 
-exports[`ambiguous > config > semi: false > <template>oops</template> > with semi, with newline > it formats ../cases/gjs/default-export.gjs 2`] = `
-"<template>
-  Explicit default export module top level component. Explicit default export
-  module top level component. Explicit default export module top level
-  component. Explicit default export module top level component. Explicit
-  default export module top level component.
-</template>
-<template>
-  oops
-</template>
-"
-`;
-
 exports[`ambiguous > config > semi: false > <template>oops</template> > with semi, with newline > it formats ../cases/gjs/exported-mod-var.gjs 1`] = `
 "export const Exported = <template>
   Exported variable template. Exported variable template. Exported variable
@@ -3492,27 +2439,7 @@ exports[`ambiguous > config > semi: false > <template>oops</template> > with sem
 "
 `;
 
-exports[`ambiguous > config > semi: false > <template>oops</template> > with semi, with newline > it formats ../cases/gjs/exported-mod-var.gjs 2`] = `
-"export const Exported = <template>
-  Exported variable template. Exported variable template. Exported variable
-  template. Exported variable template. Exported variable template. Exported
-  variable template. Exported variable template.
-</template>
-<template>
-  oops
-</template>
-"
-`;
-
 exports[`ambiguous > config > semi: false > <template>oops</template> > with semi, with newline > it formats ../cases/gjs/js-only.gjs 1`] = `
-"const num = 1
-<template>
-  oops
-</template>
-"
-`;
-
-exports[`ambiguous > config > semi: false > <template>oops</template> > with semi, with newline > it formats ../cases/gjs/js-only.gjs 2`] = `
 "const num = 1
 <template>
   oops
@@ -3534,20 +2461,6 @@ const What = <template>Hi</template>
 <template>
   oops
 </template>
-"
-`;
-
-exports[`ambiguous > config > semi: false > <template>oops</template> > with semi, with newline > it formats ../cases/gjs/mod-var.gjs 2`] = `
-"const Private = <template>
-  Private variable template. Private variable template. Private variable
-  template. Private variable template. Private variable template. Private
-  variable template. Private variable template.
-</template>
-<template>
-  oops
-</template>
-const What = <template>Hi</template>
-;<template>oops</template>
 "
 `;
 
@@ -3580,45 +2493,7 @@ const bool = false,
 "
 `;
 
-exports[`ambiguous > config > semi: false > <template>oops</template> > with semi, with newline > it formats ../cases/gjs/multiple-declarations.gjs 2`] = `
-"const ModVar1 = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template>,
-  ModVar2 = <template>Second module variable template.</template>,
-  num = 1
-<template>
-  oops
-</template>
-const bool = false,
-  ModVar3 = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template>,
-  ModVar4 = <template>Second module variable template.</template>
-<template>
-  oops
-</template>
-"
-`;
-
 exports[`ambiguous > config > semi: false > <template>oops</template> > with semi, with newline > it formats ../cases/gjs/simple.gjs 1`] = `
-"<template>
-  what
-</template>
-<template>
-  oops
-</template>
-"
-`;
-
-exports[`ambiguous > config > semi: false > <template>oops</template> > with semi, with newline > it formats ../cases/gjs/simple.gjs 2`] = `
 "<template>
   what
 </template>
@@ -3675,48 +2550,7 @@ export interface Signature {
 "
 `;
 
-exports[`ambiguous > config > semi: false > <template>oops</template> > with semi, with newline > it formats ../cases/gts/default-export.gts 2`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
-
-export interface Signature {
-  Element: HTMLElement
-  Args: {}
-  Yields: []
-}
-
-<template>
-  Explicit default export module top level component. Explicit default export
-  module top level component. Explicit default export module top level
-  component. Explicit default export module top level component. Explicit
-  default export module top level component.
-</template> as TemplateOnlyComponent<Signature>
-<template>
-  oops
-</template>
-"
-`;
-
 exports[`ambiguous > config > semi: false > <template>oops</template> > with semi, with newline > it formats ../cases/gts/exported-mod-var.gts 1`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
-
-export interface Signature {
-  Element: HTMLElement
-  Args: {}
-  Yields: []
-}
-
-export const Exported: TemplateOnlyComponent<Signature> = <template>
-  Exported variable template. Exported variable template. Exported variable
-  template. Exported variable template. Exported variable template. Exported
-  variable template. Exported variable template.
-</template>
-<template>
-  oops
-</template>
-"
-`;
-
-exports[`ambiguous > config > semi: false > <template>oops</template> > with semi, with newline > it formats ../cases/gts/exported-mod-var.gts 2`] = `
 "import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
 
 export interface Signature {
@@ -3756,35 +2590,7 @@ export const Exported = <template>
 "
 `;
 
-exports[`ambiguous > config > semi: false > <template>oops</template> > with semi, with newline > it formats ../cases/gts/exported-mod-var-with-as.gts 2`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
-
-export interface Signature {
-  Element: HTMLElement
-  Args: {}
-  Yields: []
-}
-
-export const Exported = <template>
-  Exported variable template. Exported variable template. Exported variable
-  template. Exported variable template. Exported variable template. Exported
-  variable template. Exported variable template.
-</template> as TemplateOnlyComponent<Signature>
-<template>
-  oops
-</template>
-"
-`;
-
 exports[`ambiguous > config > semi: false > <template>oops</template> > with semi, with newline > it formats ../cases/gts/js-only.gts 1`] = `
-"const num: number = 1
-<template>
-  oops
-</template>
-"
-`;
-
-exports[`ambiguous > config > semi: false > <template>oops</template> > with semi, with newline > it formats ../cases/gts/js-only.gts 2`] = `
 "const num: number = 1
 <template>
   oops
@@ -3812,47 +2618,7 @@ const Private: TemplateOnlyComponent<Signature> = <template>
 "
 `;
 
-exports[`ambiguous > config > semi: false > <template>oops</template> > with semi, with newline > it formats ../cases/gts/mod-var.gts 2`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
-
-export interface Signature {
-  Element: HTMLElement
-  Args: {}
-  Yields: []
-}
-
-const Private: TemplateOnlyComponent<Signature> = <template>
-  Private variable template. Private variable template. Private variable
-  template. Private variable template. Private variable template. Private
-  variable template. Private variable template.
-</template>
-<template>
-  oops
-</template>
-"
-`;
-
 exports[`ambiguous > config > semi: false > <template>oops</template> > with semi, with newline > it formats ../cases/gts/mod-var-with-as.gts 1`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
-
-export interface Signature {
-  Element: HTMLElement
-  Args: {}
-  Yields: []
-}
-
-const Private = <template>
-  Private variable template. Private variable template. Private variable
-  template. Private variable template. Private variable template. Private
-  variable template. Private variable template.
-</template> as TemplateOnlyComponent<Signature>
-<template>
-  oops
-</template>
-"
-`;
-
-exports[`ambiguous > config > semi: false > <template>oops</template> > with semi, with newline > it formats ../cases/gts/mod-var-with-as.gts 2`] = `
 "import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
 
 export interface Signature {
@@ -3913,46 +2679,6 @@ const bool: boolean = false,
 "
 `;
 
-exports[`ambiguous > config > semi: false > <template>oops</template> > with semi, with newline > it formats ../cases/gts/multiple-declarations.gts 2`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
-
-export interface Signature {
-  Element: HTMLElement
-  Args: {}
-  Yields: []
-}
-
-const ModVar1: TemplateOnlyComponent<Signature> = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template>,
-  ModVar2: TemplateOnlyComponent<Signature> = <template>
-    Second module variable template.
-  </template>,
-  num = 1
-<template>
-  oops
-</template>
-const bool: boolean = false,
-  ModVar3: TemplateOnlyComponent<Signature> = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template>,
-  ModVar4: TemplateOnlyComponent<Signature> = <template>
-    Second module variable template.
-  </template>
-<template>
-  oops
-</template>
-"
-`;
-
 exports[`ambiguous > config > semi: false > <template>oops</template> > with semi, with newline > it formats ../cases/gts/multiple-declarations-with-as.gts 1`] = `
 "import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
 
@@ -3994,66 +2720,7 @@ const bool: boolean = false,
 "
 `;
 
-exports[`ambiguous > config > semi: false > <template>oops</template> > with semi, with newline > it formats ../cases/gts/multiple-declarations-with-as.gts 2`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
-
-export interface Signature {
-  Element: HTMLElement
-  Args: {}
-  Yields: []
-}
-
-const ModVar1 = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template> as TemplateOnlyComponent<Signature>,
-  ModVar2 = <template>
-    Second module variable template.
-  </template> as TemplateOnlyComponent<Signature>,
-  num = 1
-<template>
-  oops
-</template>
-
-const bool: boolean = false,
-  ModVar3 = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template> as TemplateOnlyComponent<Signature>,
-  ModVar4 = <template>
-    Second module variable template.
-  </template> as TemplateOnlyComponent<Signature>
-<template>
-  oops
-</template>
-"
-`;
-
 exports[`ambiguous > config > semi: false > <template>oops</template> > with semi, with newline > it formats ../cases/gts/simple.gts 1`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
-
-export interface Signature {
-  Element: HTMLElement
-  Args: {}
-  Yields: []
-}
-
-<template>
-  what
-</template> as TemplateOnlyComponent<Signature>
-<template>
-  oops
-</template>
-"
-`;
-
-exports[`ambiguous > config > semi: false > <template>oops</template> > with semi, with newline > it formats ../cases/gts/simple.gts 2`] = `
 "import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
 
 export interface Signature {
@@ -4968,41 +3635,7 @@ class MyComponent extends Component {
 "
 `;
 
-exports[`ambiguous > config > semi: false > ["oops"] > with semi, with newline > it formats ../cases/gjs/component-class.gjs 2`] = `
-"import Component from \\"@glimmer/component\\"
-
-/** It's a component */
-class MyComponent extends Component {
-  <template>
-    <h1>
-      Class top level template. Class top level template. Class top level
-      template. Class top level template. Class top level template.
-    </h1>
-  </template>;
-  [\\"oops\\"]
-}
-"
-`;
-
 exports[`ambiguous > config > semi: false > ["oops"] > with semi, with newline > it formats ../cases/gjs/component-class-with-content-before-template.gjs 1`] = `
-"import Component from \\"@glimmer/component\\"
-
-/** It's a component */
-class MyComponent extends Component {
-  get whatever() {}
-
-  <template>
-    <h1>
-      Class top level template. Class top level template. Class top level
-      template. Class top level template. Class top level template.
-    </h1>
-  </template>;
-  [\\"oops\\"]
-}
-"
-`;
-
-exports[`ambiguous > config > semi: false > ["oops"] > with semi, with newline > it formats ../cases/gjs/component-class-with-content-before-template.gjs 2`] = `
 "import Component from \\"@glimmer/component\\"
 
 /** It's a component */
@@ -5031,28 +3664,7 @@ exports[`ambiguous > config > semi: false > ["oops"] > with semi, with newline >
 "
 `;
 
-exports[`ambiguous > config > semi: false > ["oops"] > with semi, with newline > it formats ../cases/gjs/default-export.gjs 2`] = `
-"<template>
-  Explicit default export module top level component. Explicit default export
-  module top level component. Explicit default export module top level
-  component. Explicit default export module top level component. Explicit
-  default export module top level component.
-</template>
-;[\\"oops\\"]
-"
-`;
-
 exports[`ambiguous > config > semi: false > ["oops"] > with semi, with newline > it formats ../cases/gjs/exported-mod-var.gjs 1`] = `
-"export const Exported = <template>
-  Exported variable template. Exported variable template. Exported variable
-  template. Exported variable template. Exported variable template. Exported
-  variable template. Exported variable template.
-</template>
-;[\\"oops\\"]
-"
-`;
-
-exports[`ambiguous > config > semi: false > ["oops"] > with semi, with newline > it formats ../cases/gjs/exported-mod-var.gjs 2`] = `
 "export const Exported = <template>
   Exported variable template. Exported variable template. Exported variable
   template. Exported variable template. Exported variable template. Exported
@@ -5068,26 +3680,7 @@ exports[`ambiguous > config > semi: false > ["oops"] > with semi, with newline >
 "
 `;
 
-exports[`ambiguous > config > semi: false > ["oops"] > with semi, with newline > it formats ../cases/gjs/js-only.gjs 2`] = `
-"const num = 1
-;[\\"oops\\"]
-"
-`;
-
 exports[`ambiguous > config > semi: false > ["oops"] > with semi, with newline > it formats ../cases/gjs/mod-var.gjs 1`] = `
-"const Private = <template>
-  Private variable template. Private variable template. Private variable
-  template. Private variable template. Private variable template. Private
-  variable template. Private variable template.
-</template>
-;[\\"oops\\"]
-
-const What = <template>Hi</template>
-;[\\"oops\\"]
-"
-`;
-
-exports[`ambiguous > config > semi: false > ["oops"] > with semi, with newline > it formats ../cases/gjs/mod-var.gjs 2`] = `
 "const Private = <template>
   Private variable template. Private variable template. Private variable
   template. Private variable template. Private variable template. Private
@@ -5125,31 +3718,6 @@ const bool = false,
 "
 `;
 
-exports[`ambiguous > config > semi: false > ["oops"] > with semi, with newline > it formats ../cases/gjs/multiple-declarations.gjs 2`] = `
-"const ModVar1 = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template>,
-  ModVar2 = <template>Second module variable template.</template>,
-  num = 1
-;[\\"oops\\"]
-
-const bool = false,
-  ModVar3 = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template>,
-  ModVar4 = <template>Second module variable template.</template>
-;[\\"oops\\"]
-"
-`;
-
 exports[`ambiguous > config > semi: false > ["oops"] > with semi, with newline > it formats ../cases/gjs/simple.gjs 1`] = `
 "<template>
   what
@@ -5158,39 +3726,7 @@ exports[`ambiguous > config > semi: false > ["oops"] > with semi, with newline >
 "
 `;
 
-exports[`ambiguous > config > semi: false > ["oops"] > with semi, with newline > it formats ../cases/gjs/simple.gjs 2`] = `
-"<template>
-  what
-</template>
-;[\\"oops\\"]
-"
-`;
-
 exports[`ambiguous > config > semi: false > ["oops"] > with semi, with newline > it formats ../cases/gts/component-class.gts 1`] = `
-"import Component from \\"@glimmer/component\\"
-
-export interface Signature {
-  Element: HTMLElement
-  Args: {
-    myArg: string
-  }
-  Yields: []
-}
-
-/** It's a component */
-class MyComponent extends Component<Signature> {
-  <template>
-    <h1>
-      Class top level template. Class top level template. Class top level
-      template. Class top level template. Class top level template.
-    </h1>
-  </template>;
-  [\\"oops\\"]
-}
-"
-`;
-
-exports[`ambiguous > config > semi: false > ["oops"] > with semi, with newline > it formats ../cases/gts/component-class.gts 2`] = `
 "import Component from \\"@glimmer/component\\"
 
 export interface Signature {
@@ -5233,44 +3769,7 @@ export interface Signature {
 "
 `;
 
-exports[`ambiguous > config > semi: false > ["oops"] > with semi, with newline > it formats ../cases/gts/default-export.gts 2`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
-
-export interface Signature {
-  Element: HTMLElement
-  Args: {}
-  Yields: []
-}
-
-<template>
-  Explicit default export module top level component. Explicit default export
-  module top level component. Explicit default export module top level
-  component. Explicit default export module top level component. Explicit
-  default export module top level component.
-</template> as TemplateOnlyComponent<Signature>
-;[\\"oops\\"]
-"
-`;
-
 exports[`ambiguous > config > semi: false > ["oops"] > with semi, with newline > it formats ../cases/gts/exported-mod-var.gts 1`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
-
-export interface Signature {
-  Element: HTMLElement
-  Args: {}
-  Yields: []
-}
-
-export const Exported: TemplateOnlyComponent<Signature> = <template>
-  Exported variable template. Exported variable template. Exported variable
-  template. Exported variable template. Exported variable template. Exported
-  variable template. Exported variable template.
-</template>
-;[\\"oops\\"]
-"
-`;
-
-exports[`ambiguous > config > semi: false > ["oops"] > with semi, with newline > it formats ../cases/gts/exported-mod-var.gts 2`] = `
 "import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
 
 export interface Signature {
@@ -5306,55 +3805,13 @@ export const Exported = <template>
 "
 `;
 
-exports[`ambiguous > config > semi: false > ["oops"] > with semi, with newline > it formats ../cases/gts/exported-mod-var-with-as.gts 2`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
-
-export interface Signature {
-  Element: HTMLElement
-  Args: {}
-  Yields: []
-}
-
-export const Exported = <template>
-  Exported variable template. Exported variable template. Exported variable
-  template. Exported variable template. Exported variable template. Exported
-  variable template. Exported variable template.
-</template> as TemplateOnlyComponent<Signature>
-;[\\"oops\\"]
-"
-`;
-
 exports[`ambiguous > config > semi: false > ["oops"] > with semi, with newline > it formats ../cases/gts/js-only.gts 1`] = `
 "const num: number = 1
 ;[\\"oops\\"]
 "
 `;
 
-exports[`ambiguous > config > semi: false > ["oops"] > with semi, with newline > it formats ../cases/gts/js-only.gts 2`] = `
-"const num: number = 1
-;[\\"oops\\"]
-"
-`;
-
 exports[`ambiguous > config > semi: false > ["oops"] > with semi, with newline > it formats ../cases/gts/mod-var.gts 1`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
-
-export interface Signature {
-  Element: HTMLElement
-  Args: {}
-  Yields: []
-}
-
-const Private: TemplateOnlyComponent<Signature> = <template>
-  Private variable template. Private variable template. Private variable
-  template. Private variable template. Private variable template. Private
-  variable template. Private variable template.
-</template>
-;[\\"oops\\"]
-"
-`;
-
-exports[`ambiguous > config > semi: false > ["oops"] > with semi, with newline > it formats ../cases/gts/mod-var.gts 2`] = `
 "import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
 
 export interface Signature {
@@ -5390,62 +3847,7 @@ const Private = <template>
 "
 `;
 
-exports[`ambiguous > config > semi: false > ["oops"] > with semi, with newline > it formats ../cases/gts/mod-var-with-as.gts 2`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
-
-export interface Signature {
-  Element: HTMLElement
-  Args: {}
-  Yields: []
-}
-
-const Private = <template>
-  Private variable template. Private variable template. Private variable
-  template. Private variable template. Private variable template. Private
-  variable template. Private variable template.
-</template> as TemplateOnlyComponent<Signature>
-;[\\"oops\\"]
-"
-`;
-
 exports[`ambiguous > config > semi: false > ["oops"] > with semi, with newline > it formats ../cases/gts/multiple-declarations.gts 1`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
-
-export interface Signature {
-  Element: HTMLElement
-  Args: {}
-  Yields: []
-}
-
-const ModVar1: TemplateOnlyComponent<Signature> = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template>,
-  ModVar2: TemplateOnlyComponent<Signature> = <template>
-    Second module variable template.
-  </template>,
-  num = 1
-;[\\"oops\\"]
-
-const bool: boolean = false,
-  ModVar3: TemplateOnlyComponent<Signature> = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template>,
-  ModVar4: TemplateOnlyComponent<Signature> = <template>
-    Second module variable template.
-  </template>
-;[\\"oops\\"]
-"
-`;
-
-exports[`ambiguous > config > semi: false > ["oops"] > with semi, with newline > it formats ../cases/gts/multiple-declarations.gts 2`] = `
 "import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
 
 export interface Signature {
@@ -5519,60 +3921,7 @@ const bool: boolean = false,
 "
 `;
 
-exports[`ambiguous > config > semi: false > ["oops"] > with semi, with newline > it formats ../cases/gts/multiple-declarations-with-as.gts 2`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
-
-export interface Signature {
-  Element: HTMLElement
-  Args: {}
-  Yields: []
-}
-
-const ModVar1 = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template> as TemplateOnlyComponent<Signature>,
-  ModVar2 = <template>
-    Second module variable template.
-  </template> as TemplateOnlyComponent<Signature>,
-  num = 1
-;[\\"oops\\"]
-
-const bool: boolean = false,
-  ModVar3 = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template> as TemplateOnlyComponent<Signature>,
-  ModVar4 = <template>
-    Second module variable template.
-  </template> as TemplateOnlyComponent<Signature>
-;[\\"oops\\"]
-"
-`;
-
 exports[`ambiguous > config > semi: false > ["oops"] > with semi, with newline > it formats ../cases/gts/simple.gts 1`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
-
-export interface Signature {
-  Element: HTMLElement
-  Args: {}
-  Yields: []
-}
-
-<template>
-  what
-</template> as TemplateOnlyComponent<Signature>
-;[\\"oops\\"]
-"
-`;
-
-exports[`ambiguous > config > semi: false > ["oops"] > with semi, with newline > it formats ../cases/gts/simple.gts 2`] = `
 "import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
 
 export interface Signature {
@@ -6259,28 +4608,7 @@ exports[`ambiguous > config > semi: false > \`oops\` > with semi, with newline >
 "
 `;
 
-exports[`ambiguous > config > semi: false > \`oops\` > with semi, with newline > it formats ../cases/gjs/default-export.gjs 2`] = `
-"<template>
-  Explicit default export module top level component. Explicit default export
-  module top level component. Explicit default export module top level
-  component. Explicit default export module top level component. Explicit
-  default export module top level component.
-</template>
-;\`oops\`
-"
-`;
-
 exports[`ambiguous > config > semi: false > \`oops\` > with semi, with newline > it formats ../cases/gjs/exported-mod-var.gjs 1`] = `
-"export const Exported = <template>
-  Exported variable template. Exported variable template. Exported variable
-  template. Exported variable template. Exported variable template. Exported
-  variable template. Exported variable template.
-</template>
-;\`oops\`
-"
-`;
-
-exports[`ambiguous > config > semi: false > \`oops\` > with semi, with newline > it formats ../cases/gjs/exported-mod-var.gjs 2`] = `
 "export const Exported = <template>
   Exported variable template. Exported variable template. Exported variable
   template. Exported variable template. Exported variable template. Exported
@@ -6296,26 +4624,7 @@ exports[`ambiguous > config > semi: false > \`oops\` > with semi, with newline >
 "
 `;
 
-exports[`ambiguous > config > semi: false > \`oops\` > with semi, with newline > it formats ../cases/gjs/js-only.gjs 2`] = `
-"const num = 1
-;\`oops\`
-"
-`;
-
 exports[`ambiguous > config > semi: false > \`oops\` > with semi, with newline > it formats ../cases/gjs/mod-var.gjs 1`] = `
-"const Private = <template>
-  Private variable template. Private variable template. Private variable
-  template. Private variable template. Private variable template. Private
-  variable template. Private variable template.
-</template>
-;\`oops\`
-
-const What = <template>Hi</template>
-;\`oops\`
-"
-`;
-
-exports[`ambiguous > config > semi: false > \`oops\` > with semi, with newline > it formats ../cases/gjs/mod-var.gjs 2`] = `
 "const Private = <template>
   Private variable template. Private variable template. Private variable
   template. Private variable template. Private variable template. Private
@@ -6353,31 +4662,6 @@ const bool = false,
 "
 `;
 
-exports[`ambiguous > config > semi: false > \`oops\` > with semi, with newline > it formats ../cases/gjs/multiple-declarations.gjs 2`] = `
-"const ModVar1 = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template>,
-  ModVar2 = <template>Second module variable template.</template>,
-  num = 1
-;\`oops\`
-
-const bool = false,
-  ModVar3 = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template>,
-  ModVar4 = <template>Second module variable template.</template>
-;\`oops\`
-"
-`;
-
 exports[`ambiguous > config > semi: false > \`oops\` > with semi, with newline > it formats ../cases/gjs/simple.gjs 1`] = `
 "<template>
   what
@@ -6386,34 +4670,7 @@ exports[`ambiguous > config > semi: false > \`oops\` > with semi, with newline >
 "
 `;
 
-exports[`ambiguous > config > semi: false > \`oops\` > with semi, with newline > it formats ../cases/gjs/simple.gjs 2`] = `
-"<template>
-  what
-</template>
-;\`oops\`
-"
-`;
-
 exports[`ambiguous > config > semi: false > \`oops\` > with semi, with newline > it formats ../cases/gts/default-export.gts 1`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
-
-export interface Signature {
-  Element: HTMLElement
-  Args: {}
-  Yields: []
-}
-
-<template>
-  Explicit default export module top level component. Explicit default export
-  module top level component. Explicit default export module top level
-  component. Explicit default export module top level component. Explicit
-  default export module top level component.
-</template> as TemplateOnlyComponent<Signature>
-;\`oops\`
-"
-`;
-
-exports[`ambiguous > config > semi: false > \`oops\` > with semi, with newline > it formats ../cases/gts/default-export.gts 2`] = `
 "import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
 
 export interface Signature {
@@ -6450,43 +4707,7 @@ export const Exported: TemplateOnlyComponent<Signature> = <template>
 "
 `;
 
-exports[`ambiguous > config > semi: false > \`oops\` > with semi, with newline > it formats ../cases/gts/exported-mod-var.gts 2`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
-
-export interface Signature {
-  Element: HTMLElement
-  Args: {}
-  Yields: []
-}
-
-export const Exported: TemplateOnlyComponent<Signature> = <template>
-  Exported variable template. Exported variable template. Exported variable
-  template. Exported variable template. Exported variable template. Exported
-  variable template. Exported variable template.
-</template>
-;\`oops\`
-"
-`;
-
 exports[`ambiguous > config > semi: false > \`oops\` > with semi, with newline > it formats ../cases/gts/exported-mod-var-with-as.gts 1`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
-
-export interface Signature {
-  Element: HTMLElement
-  Args: {}
-  Yields: []
-}
-
-export const Exported = <template>
-  Exported variable template. Exported variable template. Exported variable
-  template. Exported variable template. Exported variable template. Exported
-  variable template. Exported variable template.
-</template> as TemplateOnlyComponent<Signature>
-;\`oops\`
-"
-`;
-
-exports[`ambiguous > config > semi: false > \`oops\` > with semi, with newline > it formats ../cases/gts/exported-mod-var-with-as.gts 2`] = `
 "import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
 
 export interface Signature {
@@ -6510,31 +4731,7 @@ exports[`ambiguous > config > semi: false > \`oops\` > with semi, with newline >
 "
 `;
 
-exports[`ambiguous > config > semi: false > \`oops\` > with semi, with newline > it formats ../cases/gts/js-only.gts 2`] = `
-"const num: number = 1
-;\`oops\`
-"
-`;
-
 exports[`ambiguous > config > semi: false > \`oops\` > with semi, with newline > it formats ../cases/gts/mod-var.gts 1`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
-
-export interface Signature {
-  Element: HTMLElement
-  Args: {}
-  Yields: []
-}
-
-const Private: TemplateOnlyComponent<Signature> = <template>
-  Private variable template. Private variable template. Private variable
-  template. Private variable template. Private variable template. Private
-  variable template. Private variable template.
-</template>
-;\`oops\`
-"
-`;
-
-exports[`ambiguous > config > semi: false > \`oops\` > with semi, with newline > it formats ../cases/gts/mod-var.gts 2`] = `
 "import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
 
 export interface Signature {
@@ -6570,62 +4767,7 @@ const Private = <template>
 "
 `;
 
-exports[`ambiguous > config > semi: false > \`oops\` > with semi, with newline > it formats ../cases/gts/mod-var-with-as.gts 2`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
-
-export interface Signature {
-  Element: HTMLElement
-  Args: {}
-  Yields: []
-}
-
-const Private = <template>
-  Private variable template. Private variable template. Private variable
-  template. Private variable template. Private variable template. Private
-  variable template. Private variable template.
-</template> as TemplateOnlyComponent<Signature>
-;\`oops\`
-"
-`;
-
 exports[`ambiguous > config > semi: false > \`oops\` > with semi, with newline > it formats ../cases/gts/multiple-declarations.gts 1`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
-
-export interface Signature {
-  Element: HTMLElement
-  Args: {}
-  Yields: []
-}
-
-const ModVar1: TemplateOnlyComponent<Signature> = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template>,
-  ModVar2: TemplateOnlyComponent<Signature> = <template>
-    Second module variable template.
-  </template>,
-  num = 1
-;\`oops\`
-
-const bool: boolean = false,
-  ModVar3: TemplateOnlyComponent<Signature> = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template>,
-  ModVar4: TemplateOnlyComponent<Signature> = <template>
-    Second module variable template.
-  </template>
-;\`oops\`
-"
-`;
-
-exports[`ambiguous > config > semi: false > \`oops\` > with semi, with newline > it formats ../cases/gts/multiple-declarations.gts 2`] = `
 "import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
 
 export interface Signature {
@@ -6699,60 +4841,7 @@ const bool: boolean = false,
 "
 `;
 
-exports[`ambiguous > config > semi: false > \`oops\` > with semi, with newline > it formats ../cases/gts/multiple-declarations-with-as.gts 2`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
-
-export interface Signature {
-  Element: HTMLElement
-  Args: {}
-  Yields: []
-}
-
-const ModVar1 = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template> as TemplateOnlyComponent<Signature>,
-  ModVar2 = <template>
-    Second module variable template.
-  </template> as TemplateOnlyComponent<Signature>,
-  num = 1
-;\`oops\`
-
-const bool: boolean = false,
-  ModVar3 = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template> as TemplateOnlyComponent<Signature>,
-  ModVar4 = <template>
-    Second module variable template.
-  </template> as TemplateOnlyComponent<Signature>
-;\`oops\`
-"
-`;
-
 exports[`ambiguous > config > semi: false > \`oops\` > with semi, with newline > it formats ../cases/gts/simple.gts 1`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
-
-export interface Signature {
-  Element: HTMLElement
-  Args: {}
-  Yields: []
-}
-
-<template>
-  what
-</template> as TemplateOnlyComponent<Signature>
-;\`oops\`
-"
-`;
-
-exports[`ambiguous > config > semi: false > \`oops\` > with semi, with newline > it formats ../cases/gts/simple.gts 2`] = `
 "import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
 
 export interface Signature {
@@ -7268,28 +5357,7 @@ exports[`ambiguous > config > semi: false > -"oops" > with semi, with newline > 
 "
 `;
 
-exports[`ambiguous > config > semi: false > -"oops" > with semi, with newline > it formats ../cases/gjs/default-export.gjs 2`] = `
-"<template>
-  Explicit default export module top level component. Explicit default export
-  module top level component. Explicit default export module top level
-  component. Explicit default export module top level component. Explicit
-  default export module top level component.
-</template>
-;-\\"oops\\"
-"
-`;
-
 exports[`ambiguous > config > semi: false > -"oops" > with semi, with newline > it formats ../cases/gjs/exported-mod-var.gjs 1`] = `
-"export const Exported = <template>
-  Exported variable template. Exported variable template. Exported variable
-  template. Exported variable template. Exported variable template. Exported
-  variable template. Exported variable template.
-</template>
-;-\\"oops\\"
-"
-`;
-
-exports[`ambiguous > config > semi: false > -"oops" > with semi, with newline > it formats ../cases/gjs/exported-mod-var.gjs 2`] = `
 "export const Exported = <template>
   Exported variable template. Exported variable template. Exported variable
   template. Exported variable template. Exported variable template. Exported
@@ -7305,26 +5373,7 @@ exports[`ambiguous > config > semi: false > -"oops" > with semi, with newline > 
 "
 `;
 
-exports[`ambiguous > config > semi: false > -"oops" > with semi, with newline > it formats ../cases/gjs/js-only.gjs 2`] = `
-"const num = 1
-;-\\"oops\\"
-"
-`;
-
 exports[`ambiguous > config > semi: false > -"oops" > with semi, with newline > it formats ../cases/gjs/mod-var.gjs 1`] = `
-"const Private = <template>
-  Private variable template. Private variable template. Private variable
-  template. Private variable template. Private variable template. Private
-  variable template. Private variable template.
-</template>
-;-\\"oops\\"
-
-const What = <template>Hi</template>
-;-\\"oops\\"
-"
-`;
-
-exports[`ambiguous > config > semi: false > -"oops" > with semi, with newline > it formats ../cases/gjs/mod-var.gjs 2`] = `
 "const Private = <template>
   Private variable template. Private variable template. Private variable
   template. Private variable template. Private variable template. Private
@@ -7362,31 +5411,6 @@ const bool = false,
 "
 `;
 
-exports[`ambiguous > config > semi: false > -"oops" > with semi, with newline > it formats ../cases/gjs/multiple-declarations.gjs 2`] = `
-"const ModVar1 = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template>,
-  ModVar2 = <template>Second module variable template.</template>,
-  num = 1
-;-\\"oops\\"
-
-const bool = false,
-  ModVar3 = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template>,
-  ModVar4 = <template>Second module variable template.</template>
-;-\\"oops\\"
-"
-`;
-
 exports[`ambiguous > config > semi: false > -"oops" > with semi, with newline > it formats ../cases/gjs/simple.gjs 1`] = `
 "<template>
   what
@@ -7395,34 +5419,7 @@ exports[`ambiguous > config > semi: false > -"oops" > with semi, with newline > 
 "
 `;
 
-exports[`ambiguous > config > semi: false > -"oops" > with semi, with newline > it formats ../cases/gjs/simple.gjs 2`] = `
-"<template>
-  what
-</template>
-;-\\"oops\\"
-"
-`;
-
 exports[`ambiguous > config > semi: false > -"oops" > with semi, with newline > it formats ../cases/gts/default-export.gts 1`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
-
-export interface Signature {
-  Element: HTMLElement
-  Args: {}
-  Yields: []
-}
-
-<template>
-  Explicit default export module top level component. Explicit default export
-  module top level component. Explicit default export module top level
-  component. Explicit default export module top level component. Explicit
-  default export module top level component.
-</template> as TemplateOnlyComponent<Signature>
-;-\\"oops\\"
-"
-`;
-
-exports[`ambiguous > config > semi: false > -"oops" > with semi, with newline > it formats ../cases/gts/default-export.gts 2`] = `
 "import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
 
 export interface Signature {
@@ -7459,43 +5456,7 @@ export const Exported: TemplateOnlyComponent<Signature> = <template>
 "
 `;
 
-exports[`ambiguous > config > semi: false > -"oops" > with semi, with newline > it formats ../cases/gts/exported-mod-var.gts 2`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
-
-export interface Signature {
-  Element: HTMLElement
-  Args: {}
-  Yields: []
-}
-
-export const Exported: TemplateOnlyComponent<Signature> = <template>
-  Exported variable template. Exported variable template. Exported variable
-  template. Exported variable template. Exported variable template. Exported
-  variable template. Exported variable template.
-</template>
-;-\\"oops\\"
-"
-`;
-
 exports[`ambiguous > config > semi: false > -"oops" > with semi, with newline > it formats ../cases/gts/exported-mod-var-with-as.gts 1`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
-
-export interface Signature {
-  Element: HTMLElement
-  Args: {}
-  Yields: []
-}
-
-export const Exported = <template>
-  Exported variable template. Exported variable template. Exported variable
-  template. Exported variable template. Exported variable template. Exported
-  variable template. Exported variable template.
-</template> as TemplateOnlyComponent<Signature>
-;-\\"oops\\"
-"
-`;
-
-exports[`ambiguous > config > semi: false > -"oops" > with semi, with newline > it formats ../cases/gts/exported-mod-var-with-as.gts 2`] = `
 "import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
 
 export interface Signature {
@@ -7519,31 +5480,7 @@ exports[`ambiguous > config > semi: false > -"oops" > with semi, with newline > 
 "
 `;
 
-exports[`ambiguous > config > semi: false > -"oops" > with semi, with newline > it formats ../cases/gts/js-only.gts 2`] = `
-"const num: number = 1
-;-\\"oops\\"
-"
-`;
-
 exports[`ambiguous > config > semi: false > -"oops" > with semi, with newline > it formats ../cases/gts/mod-var.gts 1`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
-
-export interface Signature {
-  Element: HTMLElement
-  Args: {}
-  Yields: []
-}
-
-const Private: TemplateOnlyComponent<Signature> = <template>
-  Private variable template. Private variable template. Private variable
-  template. Private variable template. Private variable template. Private
-  variable template. Private variable template.
-</template>
-;-\\"oops\\"
-"
-`;
-
-exports[`ambiguous > config > semi: false > -"oops" > with semi, with newline > it formats ../cases/gts/mod-var.gts 2`] = `
 "import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
 
 export interface Signature {
@@ -7579,62 +5516,7 @@ const Private = <template>
 "
 `;
 
-exports[`ambiguous > config > semi: false > -"oops" > with semi, with newline > it formats ../cases/gts/mod-var-with-as.gts 2`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
-
-export interface Signature {
-  Element: HTMLElement
-  Args: {}
-  Yields: []
-}
-
-const Private = <template>
-  Private variable template. Private variable template. Private variable
-  template. Private variable template. Private variable template. Private
-  variable template. Private variable template.
-</template> as TemplateOnlyComponent<Signature>
-;-\\"oops\\"
-"
-`;
-
 exports[`ambiguous > config > semi: false > -"oops" > with semi, with newline > it formats ../cases/gts/multiple-declarations.gts 1`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
-
-export interface Signature {
-  Element: HTMLElement
-  Args: {}
-  Yields: []
-}
-
-const ModVar1: TemplateOnlyComponent<Signature> = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template>,
-  ModVar2: TemplateOnlyComponent<Signature> = <template>
-    Second module variable template.
-  </template>,
-  num = 1
-;-\\"oops\\"
-
-const bool: boolean = false,
-  ModVar3: TemplateOnlyComponent<Signature> = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template>,
-  ModVar4: TemplateOnlyComponent<Signature> = <template>
-    Second module variable template.
-  </template>
-;-\\"oops\\"
-"
-`;
-
-exports[`ambiguous > config > semi: false > -"oops" > with semi, with newline > it formats ../cases/gts/multiple-declarations.gts 2`] = `
 "import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
 
 export interface Signature {
@@ -7708,60 +5590,7 @@ const bool: boolean = false,
 "
 `;
 
-exports[`ambiguous > config > semi: false > -"oops" > with semi, with newline > it formats ../cases/gts/multiple-declarations-with-as.gts 2`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
-
-export interface Signature {
-  Element: HTMLElement
-  Args: {}
-  Yields: []
-}
-
-const ModVar1 = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template> as TemplateOnlyComponent<Signature>,
-  ModVar2 = <template>
-    Second module variable template.
-  </template> as TemplateOnlyComponent<Signature>,
-  num = 1
-;-\\"oops\\"
-
-const bool: boolean = false,
-  ModVar3 = <template>
-    <h1>
-      Module variable template. Module variable template. Module variable
-      template. Module variable template. Module variable template. Module
-      variable template. Module variable template. Module variable template.
-    </h1>
-  </template> as TemplateOnlyComponent<Signature>,
-  ModVar4 = <template>
-    Second module variable template.
-  </template> as TemplateOnlyComponent<Signature>
-;-\\"oops\\"
-"
-`;
-
 exports[`ambiguous > config > semi: false > -"oops" > with semi, with newline > it formats ../cases/gts/simple.gts 1`] = `
-"import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
-
-export interface Signature {
-  Element: HTMLElement
-  Args: {}
-  Yields: []
-}
-
-<template>
-  what
-</template> as TemplateOnlyComponent<Signature>
-;-\\"oops\\"
-"
-`;
-
-exports[`ambiguous > config > semi: false > -"oops" > with semi, with newline > it formats ../cases/gts/simple.gts 2`] = `
 "import type { TemplateOnlyComponent } from \\"@ember/component/template-only\\"
 
 export interface Signature {

--- a/tests/unit-tests/preprocessed.test.ts
+++ b/tests/unit-tests/preprocessed.test.ts
@@ -17,7 +17,7 @@ describe('format', () => {
 });
 
 function preprocessedTest(config: Config, testCase: TestCase): void {
-  test(`it formats ${testCase.name}`, () => {
+  test(`it formats ${testCase.name}`, async () => {
     const code = testCase.code.replaceAll(AMBIGUOUS_PLACEHOLDER, '');
     const preprocessed = preprocessEmbeddedTemplates(code, {
       getTemplateLocals,
@@ -30,7 +30,7 @@ function preprocessedTest(config: Config, testCase: TestCase): void {
 
       relativePath: testCase.path,
     }).output;
-    const result = format(preprocessed, config.options);
+    const result = await format(preprocessed, config.options);
     expect(result).toMatchSnapshot();
   });
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,11 @@
     "noEmit": true,
 
     // TODO: We should remove this and fix the resulting errors
-    "moduleResolution": "node"
+    "moduleResolution": "node",
+
+    "paths": {
+      "*": ["./@types/*"]
+    }
   },
   "include": ["src"]
 }


### PR DESCRIPTION
This is based on #65 by @evoactivity and @Techn1x, but with changes based on the context I have in my noggin.

- Runs `lint:prettier:fix` (Adds temp config to `.prettierrc.js` to minimize `prettier --write` diff in this PR)
- Upgrades `prettier-plugin-jsdoc` to avoid bringing prettier v2 back in as a dependency
- Removes `@types/prettier` as they are no longer necessary
- Resolves the multitude of issues caused by breaking changes. See:
   - https://prettier.io/blog/2023/07/05/3.0.0.html
   - https://github.com/prettier/prettier/wiki/How-to-migrate-my-plugin-to-support-Prettier-v3%3F
   - https://prettier.io/docs/en/api.html#custom-parser-api
- Removes the hack we were using to find and copy the unexported estree printer, because it is now exported! 🎉 