### PR TITLE
Remove `npx only-allow pnpm` preinstall hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "preexample": "vite build",
     "example": "pnpm preexample && cd examples && pnpm example",
     "example-ts": "pnpm preexample && cd examples && pnpm example-ts",
-    "preinstall": "npx only-allow pnpm",
     "lint": "concurrently \"pnpm:lint:*(!fix)\" --names \"lint:\"",
     "lint:fix": "concurrently \"pnpm:lint:*:fix\" --names \"fix:\"",
     "lint:eslint": "eslint . --cache",


### PR DESCRIPTION
While it can help first-time developers avoid a bounce, the use of `only-allow` with `npx` also means this does not work on boxes which do not have internet access, most notably internal CI boxes. Since there are alternative ways to solve the first-user flow (documentation, the fact that all package managers flag up the fact that you are using a different manager than the lock file in the repo, etc.), this removes this entirely.

Fixes #90. Alternative to #93.