### PR TITLE
Replace ember-template-imports with content-tag

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug-report.md
+++ b/.github/ISSUE_TEMPLATE/1-bug-report.md
@@ -26,7 +26,9 @@ A clear and concise description of what you expected to happen.
 ### 🌍 Environment
 
 - prettier-plugin-ember-template-tag version: -
-- ember-template-imports version: -
+- ember-template-imports version (if applicable): -
+- content-tag version (if applicable): -
+- eslint-plugin-ember version (if applicable): -
 
 ### ➕ Additional Context
 

--- a/design.md
+++ b/design.md
@@ -1,6 +1,6 @@
 # The Plan
 
-1. Run `preprocessEmbeddedTemplates` from ember-template-imports to convert gjs files with `<template>` tags into valid JS. The `<template>` tag gets converted into something like `[__GLIMMER_TEMPLATE('<h1> Hello </h1>', { strictMode: true })]`.
+1. Run `Preprocessor.process` from content-tag to convert gjs files with `<template>` tags into valid JS. The `<template>` tag gets converted into something like `[__GLIMMER_TEMPLATE('<h1> Hello </h1>', { strictMode: true })]`.
 1. Run the `estree` Prettier printer, which formats the valid JS above.
 1. Grab template contents from `GLIMMER_TEMPLATE` AST node described above.
 1. Run the hbs Prettier printer against the template contents.
@@ -11,5 +11,3 @@
      <h1>Hello</h1>
    </template>
    ```
-
-Unfortunately, this will likely involve either monkey-patching or re-implementing the estree printer due to this issue: https://github.com/prettier/prettier/issues/10259

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "@babel/core": "^7.23.2",
     "@glimmer/syntax": "^0.84.3",
     "ember-cli-htmlbars": "^6.3.0",
-    "ember-template-imports": "^3.4.2",
     "prettier": "^3.0.3"
   },
   "devDependencies": {
@@ -67,6 +66,7 @@
     "@typescript-eslint/parser": "^6.8.0",
     "@vitest/ui": "^0.34.6",
     "concurrently": "^8.2.2",
+    "content-tag": "^1.1.2",
     "eslint": "^8.51.0",
     "eslint-config-prettier": "^9.0.0",
     "eslint-plugin-eslint-comments": "^3.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,9 +17,6 @@ importers:
       ember-cli-htmlbars:
         specifier: ^6.3.0
         version: 6.3.0
-      ember-template-imports:
-        specifier: ^3.4.2
-        version: 3.4.2
       prettier:
         specifier: ^3.0.3
         version: 3.0.3
@@ -57,6 +54,9 @@ importers:
       concurrently:
         specifier: ^8.2.2
         version: 8.2.2
+      content-tag:
+        specifier: ^1.1.2
+        version: 1.1.2
       eslint:
         specifier: ^8.51.0
         version: 8.51.0
@@ -112,6 +112,9 @@ importers:
 
   tests:
     dependencies:
+      ember-template-imports:
+        specifier: ^3.4.2
+        version: 3.4.2
       prettier-plugin-ember-template-tag:
         specifier: workspace:^
         version: link:..
@@ -2043,6 +2046,10 @@ packages:
       unique-string: 3.0.0
       write-file-atomic: 3.0.3
       xdg-basedir: 5.1.0
+    dev: true
+
+  /content-tag@1.1.2:
+    resolution: {integrity: sha512-AZkfc6TUmW+/RbZJioPzOQPAHHXqyqK4B0GNckJDjBAPK3SyGrMfn21bfFky/qwi5uoLph5sjAHUkO3CL6/IgQ==}
     dev: true
 
   /convert-source-map@2.0.0:

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,13 +1,9 @@
-// @ts-expect-error FIXME: TS7016 Get ETI to export these + types
-import * as util from 'ember-template-imports/src/util.js';
-
 export const PARSER_NAME = 'ember-template-tag';
 export const PRINTER_NAME = 'ember-template-tag-estree';
 
-/* eslint-disable @typescript-eslint/no-unsafe-member-access */
-export const TEMPLATE_TAG_NAME = util.TEMPLATE_TAG_NAME as string;
-export const TEMPLATE_TAG_PLACEHOLDER = util.TEMPLATE_TAG_PLACEHOLDER as string;
-/* eslint-enable @typescript-eslint/no-unsafe-member-access */
+// FIXME: Are these still accurate?
+export const TEMPLATE_TAG_NAME = 'template';
+export const TEMPLATE_TAG_PLACEHOLDER = '__GLIMMER_TEMPLATE';
 
 export const TEMPLATE_TAG_OPEN = `<${TEMPLATE_TAG_NAME}>`;
 export const TEMPLATE_TAG_CLOSE = `</${TEMPLATE_TAG_NAME}>`;

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -6,16 +6,11 @@ import {
   isMemberExpression,
   isTaggedTemplateExpression,
 } from '@babel/types';
-import { getTemplateLocals } from '@glimmer/syntax';
-import { preprocessEmbeddedTemplates } from 'ember-template-imports/lib/preprocess-embedded-templates.js';
+import { Preprocessor } from 'content-tag';
 import type { Parser } from 'prettier';
 import { parsers as babelParsers } from 'prettier/plugins/babel.js';
 
-import {
-  PRINTER_NAME,
-  TEMPLATE_TAG_NAME,
-  TEMPLATE_TAG_PLACEHOLDER,
-} from './config';
+import { PRINTER_NAME, TEMPLATE_TAG_PLACEHOLDER } from './config';
 import type { Options } from './options.js';
 import type {
   GlimmerExpressionExtra,
@@ -41,6 +36,7 @@ import { hasAmbiguousNextLine } from './utils/ambiguity.js';
 import { assert, squish } from './utils/index.js';
 
 const typescript = babelParsers['babel-ts'] as Parser<Node | undefined>;
+const p = new Preprocessor();
 
 const preprocess: Required<Parser<Node | undefined>>['preprocess'] = (
   text: string,
@@ -54,17 +50,7 @@ const preprocess: Required<Parser<Node | undefined>>['preprocess'] = (
     preprocessed = text;
   } else {
     options.__inputWasPreprocessed = false;
-    preprocessed = preprocessEmbeddedTemplates(text, {
-      getTemplateLocals,
-
-      templateTag: TEMPLATE_TAG_NAME,
-      templateTagReplacement: TEMPLATE_TAG_PLACEHOLDER,
-
-      includeSourceMaps: false,
-      includeTemplateTokens: false,
-
-      relativePath: options.filepath,
-    }).output;
+    preprocessed = p.process(text);
   }
 
   return desugarDefaultExportTemplates(preprocessed);

--- a/tests/package.json
+++ b/tests/package.json
@@ -9,7 +9,8 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "prettier-plugin-ember-template-tag": "workspace:^"
+    "prettier-plugin-ember-template-tag": "workspace:^",
+    "ember-template-imports": "^3.4.2"
   },
   "devDependencies": {
     "typescript": "^5.2.2",

--- a/tests/unit-tests/preprocessed.test.ts
+++ b/tests/unit-tests/preprocessed.test.ts
@@ -1,9 +1,11 @@
 import { getTemplateLocals } from '@glimmer/syntax';
+import { Preprocessor } from 'content-tag';
 import { preprocessEmbeddedTemplates } from 'ember-template-imports/lib/preprocess-embedded-templates.js';
-import {
-  TEMPLATE_TAG_NAME,
-  TEMPLATE_TAG_PLACEHOLDER,
-} from 'ember-template-imports/lib/util.js';
+// FIXME: Do we need this?
+// import {
+//   TEMPLATE_TAG_NAME,
+//   TEMPLATE_TAG_PLACEHOLDER,
+// } from 'ember-template-imports/lib/util.js';
 import { describe, expect, test } from 'vitest';
 
 import { AMBIGUOUS_PLACEHOLDER } from '../helpers/ambiguous.js';
@@ -13,11 +15,41 @@ import { format } from '../helpers/format.js';
 import type { Config } from '../helpers/make-suite.js';
 import { makeSuite } from '../helpers/make-suite.js';
 
+// FIXME: Are these still accurate?
+export const TEMPLATE_TAG_NAME = 'template';
+export const TEMPLATE_TAG_PLACEHOLDER = '__GLIMMER_TEMPLATE';
+
+const p = new Preprocessor();
+
 describe('format', () => {
   makeSuite(getAllCases, preprocessedTest)({ name: 'with preprocessed code' });
+
+  /*
+   FIXME: We might not be able to maintain compatibility with
+   ember-template-imports preprocessed code, which would mean we'd have to
+   drop support for it altogether (and remove the set of tests below).
+
+   This would cause compat issues with eslint-plugin-ember until they are using
+   content-tag. Additionally, if they start using content-tag, running prettier
+   via eslint-plugin-ember won't be possible until _this_ library supports
+   content-tag.
+  */
+  makeSuite(
+    getAllCases,
+    preprocessedTestLegacy,
+  )({ name: 'with legacy ember-template-imports preprocessed code' });
 });
 
 function preprocessedTest(config: Config, testCase: TestCase): void {
+  test(`it formats ${testCase.name}`, async () => {
+    const code = testCase.code.replaceAll(AMBIGUOUS_PLACEHOLDER, '');
+    const preprocessed = p.process(code);
+    const result = await format(preprocessed, config.options);
+    expect(result).toMatchSnapshot();
+  });
+}
+
+function preprocessedTestLegacy(config: Config, testCase: TestCase): void {
   test(`it formats ${testCase.name}`, async () => {
     const code = testCase.code.replaceAll(AMBIGUOUS_PLACEHOLDER, '');
     const preprocessed = preprocessEmbeddedTemplates(code, {


### PR DESCRIPTION
Fixes https://github.com/gitKrystan/prettier-plugin-ember-template-tag/issues/149

## TODO

* [ ] I've updated the parser but the tests are failing because the AST is now different. We need to resolve the failures by updating the printer, etc.
* [ ] Attempt to support code that was pre-processed with `ember-template-imports` (see #149 for more info)