### PR TITLE
Upgrade Prettier to 3.1 (including relevant docs updates)

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,9 +53,16 @@ Prettier 3.0.0 and above
 
    _If you already have a `"prettier"` section in `package.json`, remember that takes precedence over the `.prettierrc.js` file!_
 
-1. Run `npm prettier --write . --plugin prettier-plugin-ember-template-tag`
+1. Run prettier on your codebase
 
-   See <https://github.com/gitKrystan/prettier-plugin-ember-template-tag/issues/113> and <https://github.com/prettier/prettier/issues/15351> for details on why using the `--plugin` flag is required here.
+   ```shell
+   # With prettier < 3.1
+   # See <https://github.com/gitKrystan/prettier-plugin-ember-template-tag/issues/113> and <https://github.com/prettier/prettier/issues/15351> for details on why using the `--plugin` flag is required here.
+   npm prettier --write . --plugin prettier-plugin-ember-template-tag
+
+   # With prettier >= 3.1
+   npm prettier --write .
+   ```
 
 ## Opinions
 

--- a/README.md
+++ b/README.md
@@ -56,12 +56,12 @@ Prettier 3.0.0 and above
 1. Run prettier on your codebase
 
    ```shell
+   # With prettier >= 3.1
+   npm prettier --write .
+
    # With prettier < 3.1
    # See <https://github.com/gitKrystan/prettier-plugin-ember-template-tag/issues/113> and <https://github.com/prettier/prettier/issues/15351> for details on why using the `--plugin` flag is required here.
    npm prettier --write . --plugin prettier-plugin-ember-template-tag
-
-   # With prettier >= 3.1
-   npm prettier --write .
    ```
 
 ## Opinions

--- a/examples/package.json
+++ b/examples/package.json
@@ -3,12 +3,12 @@
   "private": true,
   "version": "0.0.0",
   "scripts": {
-    "example": "pnpm exec prettier . --write --plugin prettier-plugin-ember-template-tag",
-    "example-debug": "pnpm exec prettier . --write --plugin prettier-plugin-ember-template-tag --log-level debug",
+    "example": "pnpm exec prettier . --write",
+    "example-debug": "pnpm exec prettier . --write --log-level debug",
     "test": "node ./bin/test.mjs"
   },
   "dependencies": {
-    "prettier": "^3.0.3",
+    "prettier": "^3.1.0",
     "prettier-plugin-ember-template-tag": "workspace:^"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   "dependencies": {
     "@babel/core": "^7.23.5",
     "ember-cli-htmlbars": "^6.3.0",
-    "prettier": "^3.0.3"
+    "prettier": "^3.1.0"
   },
   "devDependencies": {
     "@babel/types": "^7.23.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: ^6.3.0
         version: 6.3.0
       prettier:
-        specifier: ^3.0.3
-        version: 3.0.3
+        specifier: ^3.1.0
+        version: 3.1.0
     devDependencies:
       '@babel/types':
         specifier: ^7.23.5
@@ -80,7 +80,7 @@ importers:
         version: 0.3.10(@typescript-eslint/eslint-plugin@6.13.1)(eslint@8.54.0)(typescript@5.2.2)(vitest@0.34.6)
       prettier-plugin-jsdoc:
         specifier: ^1.1.1
-        version: 1.1.1(prettier@3.0.3)
+        version: 1.1.1(prettier@3.1.0)
       release-it:
         specifier: ^16.2.1
         version: 16.2.1(typescript@5.2.2)
@@ -97,8 +97,8 @@ importers:
   examples:
     dependencies:
       prettier:
-        specifier: ^3.0.3
-        version: 3.0.3
+        specifier: ^3.1.0
+        version: 3.1.0
       prettier-plugin-ember-template-tag:
         specifier: workspace:^
         version: link:..
@@ -4889,7 +4889,7 @@ packages:
     engines: {node: '>= 0.8.0'}
     dev: true
 
-  /prettier-plugin-jsdoc@1.1.1(prettier@3.0.3):
+  /prettier-plugin-jsdoc@1.1.1(prettier@3.1.0):
     resolution: {integrity: sha512-yA13k0StQ+g0RJBrmo2IldVSp3ANXlJdsNzQNhGtQ0LY7JFC+u01No/1Z9xp0ZhT4u98BXlPAc4SC0iambqy5A==}
     engines: {node: '>=14.13.1 || >=16.0.0'}
     peerDependencies:
@@ -4898,13 +4898,13 @@ packages:
       binary-searching: 2.0.5
       comment-parser: 1.4.0
       mdast-util-from-markdown: 2.0.0
-      prettier: 3.0.3
+      prettier: 3.1.0
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /prettier@3.0.3:
-    resolution: {integrity: sha512-L/4pUDMxcNa8R/EthV08Zt42WBO4h1rarVtK0K+QJG0X187OLo7l699jWw0GKuwzkPQ//jMFA/8Xm6Fh3J/DAg==}
+  /prettier@3.1.0:
+    resolution: {integrity: sha512-TQLvXjq5IAibjh8EpBIkNKxO749UEWABoiIZehEPiY4GNpVdhaFKqSTu+QrlU6D2dPAfubRmtJTi4K4YkQ5eXw==}
     engines: {node: '>=14'}
     hasBin: true
 


### PR DESCRIPTION
Running prettier with the `--plugin` flag won't be required anymore when prettier@3.1 will be released

This PR is here to make the doc future proof 😄 