### PR TITLE
Add optional peer-dependency on eslint-plugin-ember v12.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,13 @@
     "vitest": "^0.34.6"
   },
   "peerDependencies": {
-    "prettier": ">= 3.0.0"
+    "prettier": ">= 3.0.0",
+    "eslint-plugin-ember": ">12.0.0"
+  },
+  "peerDependenciesMeta": {
+    "eslint-plugin-ember": {
+      "optional": true
+    }
   },
   "engines": {
     "node": "18.* || >= 20"


### PR DESCRIPTION
This version of eslint-plugin-ember doesn't exist yet, but once it does, it will be the only version compatible with v2 of this plugin, since we removed support for preprocessed templates.
