### PR TITLE
test: failing test for multi-byte char before template

### DIFF
--- a/tests/cases/gts/issue-191-d.gts
+++ b/tests/cases/gts/issue-191-d.gts
@@ -1,0 +1,16 @@
+import Component from '@glimmer/component';
+
+/**
+ * This component contains a multi-byte character
+ */
+export default class MultiByteCharComponent extends Component {
+    get rows() {
+        console.log('abc다윤6')
+        return []
+    }
+  <template>
+{{#each this.rows as |row|}}
+                {{row.id}}
+{{/each}}
+  </template>
+}


### PR DESCRIPTION
Another failing test for https://github.com/gitKrystan/prettier-plugin-ember-template-tag/issues/191

Can't actually update the snapshots since this crashes out

```
 FAIL  tests/unit-tests/format.test.ts > format > config > default > it formats ../cases/gts/issue-191-d.gts
 FAIL  tests/unit-tests/config/semi-false.test.ts > config > semi: false > it formats ../cases/gts/issue-191-d.gts
 FAIL  tests/unit-tests/config/template-export-default.test.ts > config > templateExportDefault: true > it formats ../cases/gts/issue-191-d.gts
Error: failed to process all templates, 1 remaining
 ❯ convertAst src/parse/index.ts:74:11
     72| 
     73|   if (unprocessedTemplates.length > 0) {
     74|     throw new Error(
       |           ^
     75|       `failed to process all templates, ${unprocessedTemplates.length} remaining`,
     76|     );
 ❯ Object.parse src/parse/index.ts:109:5
 ❯ parse node_modules/.pnpm/prettier@3.1.1/node_modules/prettier/index.mjs:19362:11
 ❯ coreFormat node_modules/.pnpm/prettier@3.1.1/node_modules/prettier/index.mjs:20683:7
 ❯ formatWithCursor node_modules/.pnpm/prettier@3.1.1/node_modules/prettier/index.mjs:20885:14
 ❯ Module.format2 node_modules/.pnpm/prettier@3.1.1/node_modules/prettier/index.mjs:24517:25
 ❯ Module.format tests/helpers/format.ts:23:10
 ❯ tests/helpers/make-suite.ts:58:20
```