### PR TITLE
chore: Add test for negative range error

### DIFF
--- a/tests/cases/gts/issue-255.gts
+++ b/tests/cases/gts/issue-255.gts
@@ -1,0 +1,14 @@
+import Component from '@glimmer/component';
+
+export default class PooComponent extends Component {
+  <template>
+                  Testing line, incorrectly indented.
+    {{#if true}}
+      {{#if true}}
+        <link href="/////styles/" />
+      {{else}}
+        <link href="/////styles/" />
+      {{/if}}
+    {{/if}}
+  </template>
+}


### PR DESCRIPTION
- Tests are not passing as the addon will crash. Also could not update the snapshots because of that.
- Not sure if this will be useful, but whoever understands how to fix the issue can maybe use this as basis?
- Test covering case for #255