### PR TITLE
Fix for preprocessTemplateRange & forward slashes

### DIFF
--- a/src/parse/index.ts
+++ b/src/parse/index.ts
@@ -92,24 +92,14 @@ function convertAst(ast: File, templates: Template[]): void {
  * fixing the offsets and locations of all nodes also calculates the block
  * params locations & ranges and adding it to the info
  */
-function preprocess(
+export function preprocess(
   code: string,
   fileName: string,
 ): {
   code: string;
   templates: Template[];
 } {
-  const rawTemplates = p.parse(code, fileName);
-  const templates: Template[] = rawTemplates.map((r) => ({
-    type: r.type,
-    range: r.range,
-    contentRange: r.contentRange,
-    contents: r.contents,
-    utf16Range: {
-      start: byteToCharIndex(code, r.range.start),
-      end: byteToCharIndex(code, r.range.end),
-    },
-  }));
+  const templates = codeToGlimmerAst(code, fileName);
 
   for (const template of templates) {
     code = preprocessTemplateRange(template, code);
@@ -130,3 +120,20 @@ export const parser: Parser<Node | undefined> = {
     return ast;
   },
 };
+
+/** Pre-processes the template info, parsing the template content to Glimmer AST. */
+export function codeToGlimmerAst(code: string, fileName: string): Template[] {
+  const rawTemplates = p.parse(code, fileName);
+  const templates: Template[] = rawTemplates.map((r) => ({
+    type: r.type,
+    range: r.range,
+    contentRange: r.contentRange,
+    contents: r.contents,
+    utf16Range: {
+      start: byteToCharIndex(code, r.range.start),
+      end: byteToCharIndex(code, r.range.end),
+    },
+  }));
+
+  return templates;
+}

--- a/src/parse/preprocess.ts
+++ b/src/parse/preprocess.ts
@@ -13,6 +13,8 @@ export interface Template {
 
 const BufferMap: Map<string, Buffer> = new Map();
 
+export const PLACEHOLDER = '~';
+
 function getBuffer(s: string): Buffer {
   let buf = BufferMap.get(s);
   if (!buf) {
@@ -76,7 +78,9 @@ export function preprocessTemplateRange(
     }
   }
 
-  const content = template.contents.replaceAll('/', '\\/');
+  // We need to replace forward slash with _something else_, because
+  // forward slash breaks the parsed templates.
+  const content = template.contents.replaceAll('/', PLACEHOLDER);
   const tplLength = template.range.end - template.range.start;
   const spaces =
     tplLength - byteLength(content) - prefix.length - suffix.length;

--- a/tests/cases/gts/issue-255.gts
+++ b/tests/cases/gts/issue-255.gts
@@ -1,0 +1,15 @@
+import Component from '@glimmer/component';
+
+export default class PooComponent extends Component {
+  <template>
+                  Testing line, incorrectly indented.
+    {{#if true}}
+      {{#if true}}
+        <link href="/////styles/" />
+        /* hi */
+      {{else}}
+        <link href="/////styles/" />
+      {{/if}}
+    {{/if}}
+  </template>
+}

--- a/tests/unit-tests/__snapshots__/format.test.ts.snap
+++ b/tests/unit-tests/__snapshots__/format.test.ts.snap
@@ -542,6 +542,25 @@ export default class MultiByteCharComponent extends Component {
 "
 `;
 
+exports[`format > config > default > it formats ../cases/gts/issue-255.gts 1`] = `
+"import Component from "@glimmer/component";
+
+export default class PooComponent extends Component {
+  <template>
+    Testing line, incorrectly indented.
+    {{#if true}}
+      {{#if true}}
+        <link href="/////styles/" />
+        /* hi */
+      {{else}}
+        <link href="/////styles/" />
+      {{/if}}
+    {{/if}}
+  </template>
+}
+"
+`;
+
 exports[`format > config > default > it formats ../cases/gts/js-only.gts 1`] = `
 "const num: number = 1;
 "

--- a/tests/unit-tests/ambiguous/__snapshots__/semi-false.test.ts.snap
+++ b/tests/unit-tests/ambiguous/__snapshots__/semi-false.test.ts.snap
@@ -4217,24 +4217,6 @@ class MyComponent extends Component {
 "
 `;
 
-exports[`ambiguous > config > semi: false > ["oops"] > with semi, with newline > it formats ../cases/gjs/component-class-with-content-before-template.gjs 2`] = `
-"import Component from "@glimmer/component"
-
-/** It's a component */
-class MyComponent extends Component {
-  get whatever() {}
-
-  <template>
-    <h1>
-      Class top level template. Class top level template. Class top level
-      template. Class top level template. Class top level template.
-    </h1>
-  </template>
-  ["oops"]
-}
-"
-`;
-
 exports[`ambiguous > config > semi: false > ["oops"] > with semi, with newline > it formats ../cases/gjs/default-export.gjs 1`] = `
 "<template>
   Explicit default export module top level component. Explicit default export

--- a/tests/unit-tests/config/__snapshots__/semi-false.test.ts.snap
+++ b/tests/unit-tests/config/__snapshots__/semi-false.test.ts.snap
@@ -542,6 +542,25 @@ export default class MultiByteCharComponent extends Component {
 "
 `;
 
+exports[`config > semi: false > it formats ../cases/gts/issue-255.gts 1`] = `
+"import Component from "@glimmer/component"
+
+export default class PooComponent extends Component {
+  <template>
+    Testing line, incorrectly indented.
+    {{#if true}}
+      {{#if true}}
+        <link href="/////styles/" />
+        /* hi */
+      {{else}}
+        <link href="/////styles/" />
+      {{/if}}
+    {{/if}}
+  </template>
+}
+"
+`;
+
 exports[`config > semi: false > it formats ../cases/gts/js-only.gts 1`] = `
 "const num: number = 1
 "

--- a/tests/unit-tests/config/__snapshots__/template-export-default.test.ts.snap
+++ b/tests/unit-tests/config/__snapshots__/template-export-default.test.ts.snap
@@ -542,6 +542,25 @@ export default class MultiByteCharComponent extends Component {
 "
 `;
 
+exports[`config > templateExportDefault: true > it formats ../cases/gts/issue-255.gts 1`] = `
+"import Component from "@glimmer/component";
+
+export default class PooComponent extends Component {
+  <template>
+    Testing line, incorrectly indented.
+    {{#if true}}
+      {{#if true}}
+        <link href="/////styles/" />
+        /* hi */
+      {{else}}
+        <link href="/////styles/" />
+      {{/if}}
+    {{/if}}
+  </template>
+}
+"
+`;
+
 exports[`config > templateExportDefault: true > it formats ../cases/gts/js-only.gts 1`] = `
 "const num: number = 1;
 "

--- a/tests/unit-tests/preprocess.test.ts
+++ b/tests/unit-tests/preprocess.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from 'vitest';
+
+import { codeToGlimmerAst } from '../../src/parse/index.js';
+import {
+  PLACEHOLDER,
+  preprocessTemplateRange,
+} from '../../src/parse/preprocess.js';
+
+const TEST_CASES = [
+  {
+    code: '<template>hi</template>',
+    expected: [`{/*hi               */}`],
+  },
+  {
+    code: '<template>/* hi */</template>',
+    expected: [`{/*${PLACEHOLDER}* hi *${PLACEHOLDER}               */}`],
+  },
+  {
+    code: '<template><div>hi</div></template>',
+    expected: [`{/*<div>hi<${PLACEHOLDER}div>               */}`],
+  },
+  {
+    code: '<template>{{#if true}}hi{{/if}}</template>',
+    expected: [`{/*{{#if true}}hi{{${PLACEHOLDER}if}}               */}`],
+  },
+  {
+    code: '<template>////////////////</template>',
+    expected: [
+      `{/*${PLACEHOLDER}${PLACEHOLDER}${PLACEHOLDER}${PLACEHOLDER}${PLACEHOLDER}${PLACEHOLDER}${PLACEHOLDER}${PLACEHOLDER}${PLACEHOLDER}${PLACEHOLDER}${PLACEHOLDER}${PLACEHOLDER}${PLACEHOLDER}${PLACEHOLDER}${PLACEHOLDER}${PLACEHOLDER}               */}`,
+    ],
+  },
+  {
+    code: '<template>💩</template>',
+    expected: [`{/*💩               */}`],
+  },
+  {
+    code: 'const a = <template>foo</template>; const b = <template>bar</template>;',
+    expected: [
+      `const a = {/*foo               */}; const b = <template>bar</template>;`,
+      `const a = <template>foo</template>; const b = {/*bar               */};`,
+    ],
+  },
+  {
+    code: `const a = <template>💩💩💩💩💩💩💩</template>; const b = <template>💩</template>`,
+    expected: [
+      `const a = {/*💩💩💩💩💩💩💩               */}; const b = <template>💩</template>`,
+      `const a = <template>💩💩💩💩💩💩💩</template>; const b = {/*💩               */}`,
+    ],
+  },
+];
+const FILE_NAME = 'foo.gts';
+
+describe('preprocess', () => {
+  for (const testCase of TEST_CASES) {
+    test(`preprocessTemplateRange ${testCase.code}`, () => {
+      const templates = codeToGlimmerAst(testCase.code, FILE_NAME);
+      for (const [index, template] of templates.entries()) {
+        const received = preprocessTemplateRange(template, testCase.code);
+        expect(received).toEqual(testCase.expected[index]);
+        expect(received).toHaveLength(testCase.code.length);
+      }
+    });
+  }
+});


### PR DESCRIPTION
- Fixes #255.
- Issues stems from templates that have forward slash in them. Which are pretty much all of them: `</div>` or `{{/if}}` will be an issue.
- I extracted `codeToGlimmerAst` functionality to DRY the code.
- I experimented with many variants of the code as I believed that we don't need to put the whole `content` into the replaced template [like here](https://github.com/gitKrystan/prettier-plugin-ember-template-tag/blob/main/src/parse/preprocess.ts#L83), but I could not find a combination that would work. So I *believe* it's a combination of `template.contents`, `template.range.end`, `template.range.start` operating in different "units" and then something breaks when there is different number of multibyte characters. So I decided to keep the `template.contents` as is and use the `PLACEHOLDER` instead.
- For now I just decided to set `PLACEHOLDER = '-';`. Is that a bad idea? All tests are green ...
- I added tons of units tests for `preprocess.ts` to make sure that function in isolation works as expected.