### PR TITLE
Add config for Corepack

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,5 +99,6 @@
       "internal": ":house: Internal",
       "dependencies": ":robot: Dependencies"
     }
-  }
+  },
+  "packageManager": "pnpm@8.13.1"
 }


### PR DESCRIPTION
My local environment always complains that:

```
! The local project doesn't define a 'packageManager' field. Corepack will now add one referencing pnpm@8.15.5+sha256.4b4efa12490e5055d59b9b9fc9438b7d581a6b7af3b5675eb5c5f447cee1a589.
! For more details about this field, consult the documentation at https://nodejs.org/api/packages.html#packagemanager
```

And adds this line to `package.json`.

So I thought I will just create a PR that will make the change so that I don't have to revert it all the time...