### PR TITLE
VSCode settings cleanup

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,6 +10,6 @@
   // Turn off this formatter so Prettier will be the only formatter and the user won't have to pick.
   "javascript.format.enable": false,
   "editor.codeActionsOnSave": {
-    "source.fixAll": true
+    "source.fixAll": "explicit"
   }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,6 @@
 {
   "explorer.excludeGitIgnore": true,
   "npm.packageManager": "pnpm",
-  "eslint.packageManager": "pnpm",
 
   "editor.formatOnSave": true,
   "[javascript]": {


### PR DESCRIPTION
## source.fixAll

My `vscode` is:

```
Version: 1.87.2
Commit: 863d2581ecda6849923a2118d93a088b0745d9d6
Date: 2024-03-08T15:21:31.043Z
Electron: 27.3.2
ElectronBuildId: 26836302
Chromium: 118.0.5993.159
Node.js: 18.17.1
V8: 11.8.172.18-electron.0
OS: Darwin x64 23.4.0
```

And it always does this change upon project reload. The hint in my vscode settings says following about `true` value:

```
Triggers Code Actions only when explicitly saved. This value will be deprecated in favor of "explicit".
```

## eslint.packageManager

My vscode says about this property:

```
The setting is deprecated. The Package Manager is automatically detected now.
```