### PR TITLE
chore: use HTTPS repository metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:ember-tooling/prettier-plugin-ember-template-tag.git"
+    "url": "git+https://github.com/ember-tooling/prettier-plugin-ember-template-tag.git"
   },
   "license": "MIT",
   "author": {


### PR DESCRIPTION
## Summary
- update package repository metadata from SSH to `git+https`
- leave runtime code, dependencies, homepage, bugs metadata, and package contents unchanged

## Validation
- node metadata assertion
- corepack pnpm install --frozen-lockfile --ignore-scripts
- corepack pnpm lint
- corepack pnpm build
- corepack pnpm test:run
- npm pack --dry-run --ignore-scripts --json .
- git diff --check
